### PR TITLE
Add sagital view to g2p phoneme details

### DIFF
--- a/apps/web/src/app/[locale]/(g2p)/_components/phoneme-compact-block.tsx
+++ b/apps/web/src/app/[locale]/(g2p)/_components/phoneme-compact-block.tsx
@@ -7,6 +7,7 @@ import {
 	PhonemeDetailsExamples,
 	PhonemeDetailsGuide,
 	PhonemeDetailsHeader,
+	PhonemeDetailsSagittalView,
 } from "@/components/phoneme-details";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -50,6 +51,7 @@ export function PhonemeCompactBlock() {
 							<PhonemeDetailsExamples />
 							<PhonemeDetailsGuide />
 							<PhonemeDetailsAllophones />
+							<PhonemeDetailsSagittalView />
 						</div>
 					</ScrollArea>
 				</CardContent>


### PR DESCRIPTION
Add sagittal view to phoneme details on the G2P page.

---
<a href="https://cursor.com/background-agent?bcId=bc-01922e5d-6ccd-42b9-9bd4-2fcd89cfb598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01922e5d-6ccd-42b9-9bd4-2fcd89cfb598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

