### PR TITLE
docs: refresh readme content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,70 @@
 # Phonix
 
-Phonix is a phoneme-first ESL pronunciation project focused on helping learners hear and produce the sounds of American English (General American). It emphasizes clear, approachable IPA-based learning and connects individual phonemes to real-word usage.
+Phonix is a phoneme-first ESL pronunciation project built around a modern Next.js application. Learners explore General American phonemes through interactive IPA charts, grapheme-to-phoneme (G2P) transcription, and in-context dictionary lookups with audio support.
 
-## Project Overview
+## Highlights
 
-This is a monorepo managed with `pnpm` workspaces, consisting of:
+- **Audio-first learning** – Interactive phoneme dialogs with minimal pairs, production tips, and optional ElevenLabs example audio.
+- **Fast G2P service** – A bundled CMU Pronouncing Dictionary powers instant transcription and phoneme highlighting.
+- **Dictionary integration** – Clickable transcriptions surface word definitions and available pronunciation audio in a side drawer.
+- **Shared phoneme metadata** – Typed phoneme data and articulation metadata are reusable across the app and helper tooling.
 
-- `apps/web`: The main Next.js application combining frontend and API for interactive phoneme learning.
-- `packages/shared-data`: Shared data models and utilities for phoneme information.
-- `packages/helper-scripts`: Collection of helper scripts including TTS audio generation and data processing utilities.
+## Monorepo layout
 
-## Current Status
+| Package | Description |
+| --- | --- |
+| [`apps/web`](apps/web/README.md) | Next.js App Router project containing the learner experience and API routes. |
+| [`packages/shared-data`](packages/shared-data/README.md) | Source of truth for phoneme metadata, articulation registries, and helper utilities. |
+| [`packages/helper-scripts`](packages/helper-scripts/README.md) | ElevenLabs audio generation and CMUDict tooling that feed the web app. |
+| [`docs`](docs/README.md) | Product briefs, technical design notes, and feature deep-dives. |
 
-We are currently implementing the Core MVP features, specifically focusing on phoneme awareness, transcription, and dictionary lookup. The project includes interactive IPA charts, phoneme dialogs with audio examples, a concise dictionary side panel (with pronunciation audio when available), and a comprehensive data model for 40 English phonemes.
-
-## Development
+## Getting started
 
 ### Prerequisites
 
-- [pnpm](https://pnpm.io/)
-- Node.js (version specified in `package.json` engines field)
+- [pnpm](https://pnpm.io/) 10+
+- Node.js 18.18 or newer (matching the Next.js support matrix)
 
-### Quick Start
+### Installation & local development
 
-1. **Install dependencies:**
-   ```bash
-   pnpm install
-   ```
+```bash
+pnpm install            # install workspace dependencies once
+pnpm -C apps/web dev    # launch the learner experience at http://localhost:3000
+```
 
-2. **Start the application:**
-   ```bash
-   pnpm -C apps/web dev
-   ```
+The root `pnpm dev` command delegates to Turborepo and will start every package with a `dev` script. Use package-specific commands (shown above) for a focused workflow.
 
-   The Next.js app will be available at `http://localhost:3000` with both the frontend and API running together.
+## Common workspace tasks
 
-3. **(Optional) Generate example audio:**
-   - Add your `ELEVENLABS_API_KEY` to `packages/helper-scripts/.env`.
-   - Run the generation script:
-     ```bash
-     pnpm -C packages/helper-scripts generate
-     ```
+```bash
+pnpm lint         # run Biome across packages
+pnpm check-types  # run TypeScript in --noEmit mode
+pnpm test         # execute Vitest suites (filtered via Turborepo)
+pnpm build        # build all packages for production
+```
 
-## Project Structure
+All commits should pass linting, type checking, and relevant tests.
 
-For detailed information about each package, see their respective README files:
+## Data & helper workflows
 
-- [Next.js Application](apps/web/README.md)
-- [Shared Data Package](packages/shared-data/README.md)
-- [Helper Scripts Package](packages/helper-scripts/README.md)
+Phonix ships with pre-generated assets but also supports regeneration when source data changes:
 
-## New: Dictionary Lookup
+- **CMU Pronouncing Dictionary** – Stored at `apps/web/data/cmudict.json` and bundled with the API for fast lookups. Regenerate with:
+  ```bash
+  CMUDICT_SRC_URL="<remote .dict file>" pnpm -C packages/helper-scripts cmudict-to-json
+  ```
+  Use `CMUDICT_JSON_PATH` to override the default output location.
+- **Example audio** – ElevenLabs powered `.mp3` files saved to `apps/web/public/audio/examples`. Provide an `ELEVENLABS_API_KEY` in `packages/helper-scripts/.env` and run:
+  ```bash
+  pnpm -C packages/helper-scripts generate
+  ```
 
-- Click any word in G2P results to view definitions in a side panel.
-- Pronunciation audio plays when provided by the dictionary source.
-- API: `GET /api/dictionary?word=<word>` → `{ success, data }` or `404` with `{ error: "not_found" }`.
+Generated assets are committed so deployments remain deterministic.
+
+## Documentation
+
+Deeper product context, enhancement plans, and feature briefs live in the [`docs`](docs/README.md) directory. Start with the [project overview](docs/project-overview.md) for a guided tour and explore enhancement plans or feature notes as needed.
+
+## Licensing
+
+Phonix is distributed under the MIT License. The embedded CMU Pronouncing Dictionary follows its original [BSD-3-Clause license](CMUdict-BSD-3-LICENSE.md).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,123 +1,67 @@
-# Phonix Next.js Application
+# Phonix – Web Application
 
-This is the main Next.js application for Phonix, a phoneme-first ESL pronunciation learning platform. It combines both the frontend user interface and the backend API into a single, unified Next.js application using the App Router.
+This package hosts the primary Phonix experience: a Next.js App Router project that delivers IPA charts, grapheme-to-phoneme transcription, dictionary lookups, and pronunciation audio for ESL learners.
 
-## Features
+## Feature overview
 
-- **Interactive IPA Charts**: Explore English phonemes with clickable charts
-- **G2P Transcription**: Convert text to phonemic transcription using CMU Dictionary
-- **Word Definitions**: Click a word in results to view definitions in a side panel
-- **Pronunciation Audio**: Play dictionary audio for words when available
-- **Dark/Light Theme**: Built-in theme switching with next-themes
-- **Responsive Design**: Mobile-first approach with shadcn/ui components
-- **Type Safety**: Full TypeScript implementation with strict settings
+- **Interactive IPA chart** – Explore 40 General American phonemes with articulation metadata, example words, and optional ElevenLabs audio.
+- **Grapheme-to-phoneme transcription** – `POST /api/g2p` converts user text into IPA with highlighted phoneme matches.
+- **Dictionary side drawer** – Clicking a word shows definitions and pronunciation audio via `GET /api/dictionary`.
+- **Themeable & responsive UI** – Tailwind CSS v4, shadcn/ui primitives, and next-themes provide a polished experience across devices.
+- **Internationalization ready** – `src/i18n` exposes next-intl configuration for future locale support.
 
-## Tech Stack
+## Tech stack
 
-- **Framework**: Next.js 15 with App Router
-- **Styling**: Tailwind CSS v4 with custom theme colors
-- **UI Components**: shadcn/ui with Radix UI primitives
-- **TypeScript**: Strict configuration with path aliases
-- **Linting**: Biome (extends root workspace configuration)
-- **Package Manager**: pnpm with workspace support
+- **Framework** – Next.js 15 (App Router, Turbopack dev server)
+- **Language** – TypeScript with strict settings and path aliases (`@/`)
+- **Styling** – Tailwind CSS v4, CSS variables managed in `src/app/globals.css`
+- **State & data** – React Query (for async flows), Zustand (lightweight client stores)
+- **Testing** – Vitest with utility-first unit coverage for API services and hooks
+- **Linting** – Biome (shared workspace configuration)
 
-## API Routes
+## Running locally
 
-- `GET /api/health` - Health check endpoint
-- `POST /api/g2p` - Convert text to phonemic transcription
-- `GET /api/dictionary?word=<word>` - Fetch dictionary definition for a word
-
-## Development
-
-### Prerequisites
-
-- Node.js (see root package.json for version)
-- pnpm
-
-### Local Development
-
-1. **Install dependencies:**
-   ```bash
-   pnpm install
-   ```
-
-2. **Start development server:**
-   ```bash
-   pnpm dev
-   ```
-
-3. **Open [http://localhost:3000](http://localhost:3000)**
-
-### Available Scripts
-
-- `pnpm dev` - Start development server with Turbopack
-- `pnpm build` - Build for production
-- `pnpm start` - Start production server
-- `pnpm lint` - Run Biome linter and formatter
-- `pnpm typecheck` - Run TypeScript type checking
-
-## Project Structure
-
-```
-src/
-├── app/                    # Next.js App Router pages and API routes
-│   ├── api/               # API route handlers
-│   ├── globals.css        # Global styles and theme variables
-│   ├── layout.tsx         # Root layout with theme provider
-│   └── page.tsx           # Home page (G2P transcription)
-├── components/            # Reusable React components
-│   ├── ui/               # shadcn/ui components
-│   ├── g2p/              # G2P-specific components
-│   ├── chart/            # IPA chart components
-│   └── core/             # Core phoneme components
-├── hooks/                # Custom React hooks
-├── lib/                  # Utility functions and configurations
-│   ├── g2p/              # G2P service and utilities
-│   └── shared/           # Shared utilities
-└── types/                # TypeScript type definitions
+```bash
+pnpm install             # once per workspace
+pnpm -C apps/web dev     # start Next.js at http://localhost:3000
 ```
 
-## Key Dependencies
+The root `pnpm dev` will also start this project if you prefer Turborepo orchestration.
 
-- `shared-data` - Shared phoneme data and utilities
-- `@tanstack/react-query` - (Optional) Data fetching and caching
-- `next-themes` - Theme switching functionality
-- `zod` - Runtime type validation
-- `lucide-react` - Icon library
-- `sonner` - Toast notifications
+### Useful scripts
 
-## G2P and CMUDict (Design & Rationale)
+```bash
+pnpm -C apps/web lint            # biome check --write
+pnpm -C apps/web check-types     # tsc --noEmit
+pnpm -C apps/web test            # vitest run
+pnpm -C apps/web build           # next build --turbopack
+pnpm -C apps/web start           # next start (after build)
+```
 
-### What powers G2P
+## Directory structure
 
-- **Source**: CMU Pronouncing Dictionary (compact JSON) at `apps/web/data/cmudict.json` (~4.5MB)
-- **Loader**: `apps/web/src/app/api/g2p/_lib/cmudict.ts`
-- **API**: `POST /api/g2p` (see `apps/web/src/app/api/g2p/route.ts`)
+```
+apps/web
+├── data/                 # Bundled CMU Pronouncing Dictionary JSON
+├── public/audio/         # ElevenLabs example audio (optional)
+├── src/
+│   ├── app/              # Routes, layouts, and API handlers (App Router)
+│   │   ├── api/          # REST endpoints (e.g., g2p, dictionary)
+│   │   └── (routes)      # Feature entry points
+│   ├── components/       # Reusable UI components (feature folders under chart/, g2p/, core/, ui/)
+│   ├── hooks/            # Custom React hooks
+│   ├── i18n/             # next-intl configuration and messages
+│   └── lib/              # Client/server utilities (g2p helpers, dictionary services, design tokens)
+├── global.ts             # Shared runtime configuration
+├── messages/             # Localized message bundles (per locale)
+└── vitest.config.ts      # Test runner configuration
+```
 
-### Why static JSON import (not FS or network)
+## Data dependencies
 
-- **Reliability on Vercel**: Avoids path resolution issues (e.g., ENOENT) that occur when reading from `process.cwd()` within serverless bundles.
-- **Zero network on hot path**: No fetch from `public/` or external bucket; keeps the request path fast and predictable.
-- **Bundled with the server**: Ensures the dictionary ships with the function and is available at cold start. It's also using the Node.js runtime to make sure it has enough memory to load the dictionary.
+- **CMU Pronouncing Dictionary** – Expected at `apps/web/data/cmudict.json`. Regenerate via `pnpm -C packages/helper-scripts cmudict-to-json` (see helper-scripts README).
+- **Example audio** – Optional `.mp3` files under `public/audio/examples`. Generated with `pnpm -C packages/helper-scripts generate` once `ELEVENLABS_API_KEY` is configured.
 
-### One-time load, safe for concurrency
+## Testing guidance
 
-- `cmudict.ts` maintains module-level state:
-  - `loaded` flag and a shared `loadPromise`.
-  - First request triggers the load; concurrent requests await the same promise (prevents duplicate work).
-  - After load, the dictionary lives in memory for the lifetime of the instance and is reused across requests.
-- This plays well with Vercel Fluid Compute: multiple concurrent requests on the same instance share the loaded data.
-
-### Performance characteristics
-
-- Cold start does the initial JSON parse and phoneme mapping, then all lookups are in-memory.
-- No per-request file I/O or network I/O.
-- If cold-start CPU becomes a concern, consider an alternative strategy:
-  - Store ARPABET variants in memory, convert to IPA on demand, and cache per word.
-  - Or shard the JSON by first letter and lazily import only needed shards.
-  - Or use Redis to store records for highly requested words.
-
-### Regenerating `cmudict.json`
-
-- Use the helper script in `packages/helper-scripts` (see that package's README) to download and convert CMUDict to JSON.
-- Place the output at `apps/web/data/cmudict.json` to be bundled with the app.
+Unit tests live alongside the code they cover (e.g., `src/app/api/dictionary/_services/dictionary-service.test.ts`). Run `pnpm -C apps/web test` locally or rely on the root `pnpm test` command for workspace-wide coverage.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,25 @@
 # Phonix Documentation
 
-This directory contains comprehensive documentation for the Phonix project.
+This directory centralizes long-form product context, technical deep-dives, and feature briefs for the Phonix project. Use it alongside the package READMEs to understand the rationale behind major systems and upcoming enhancements.
 
-## Documents
+## Directory map
 
-- **[Project Overview](./project-overview.md)** - High-level product, UX, and technical architecture overview, including the dictionary lookup feature and pronunciation audio.
-- **[G2P Enhancement Implementation Plan](./g2p-enhancement-plan.md)** - Complete technical specification and implementation guide for improving the Grapheme-to-Phoneme system with homograph disambiguation and performance optimization.
+- [`project-overview.md`](./project-overview.md) – A guided tour of the learner experience, architecture, and data sources (including dictionary lookup and audio strategy).
+- [`enhancements/g2p-plan.md`](./enhancements/g2p-plan.md) – Three-phase roadmap for evolving the grapheme-to-phoneme pipeline with homograph disambiguation and performance wins.
+- [`features/minimal-pairs.md`](./features/minimal-pairs.md) – Product notes and UX considerations for future minimal pair drills inside the IPA chart experience.
 
-## Quick Overview
+Add new documents in logical subfolders (`enhancements/`, `features/`, etc.) to keep related work clustered and easily discoverable.
 
-The system focuses on phoneme-first learning with interactive charts, G2P transcription, and in-context dictionary lookup (with audio when available). The G2P Enhancement Plan outlines a three-phase approach to improve pronunciation accuracy and system performance:
+## When to read what
 
-1. **Phase 1: Foundation** - Optimize dictionary loading and support pronunciation variants
-2. **Phase 2: Intelligence** - Add context-aware homograph disambiguation 
-3. **Phase 3: Performance** - Implement hybrid architecture for optimal speed and bundle size
+| Scenario | Start here |
+| --- | --- |
+| New to the project | [`project-overview.md`](./project-overview.md) for context on goals, personas, and technical architecture. |
+| Working on the G2P service | [`enhancements/g2p-plan.md`](./enhancements/g2p-plan.md) to understand the current baseline and proposed improvements. |
+| Exploring future feature work | [`features/minimal-pairs.md`](./features/minimal-pairs.md) for the next UX milestone. |
 
-Each phase builds incrementally on the previous while maintaining full functionality and backward compatibility.
+## Contributing documentation
+
+1. Keep filenames descriptive and use kebab-case.
+2. Update this README with a short description when new docs are added so the directory remains discoverable.
+3. Cross-link to relevant code packages or other documents where it helps the reader connect the dots.

--- a/packages/helper-scripts/README.md
+++ b/packages/helper-scripts/README.md
@@ -1,85 +1,45 @@
-# Helper Scripts Package
+# Helper Scripts
 
-This package contains various helper scripts for the Phonix application, including Text-to-Speech (TTS) audio generation and data processing utilities.
+Utility scripts that back the Phonix web application. They generate reusable assets (example audio and CMU Pronouncing Dictionary JSON) and provide lint/type checks for the package itself.
 
-## Available Scripts
+## Prerequisites
 
-### 1. TTS Audio Generation
+- `pnpm install` at the workspace root
+- Node.js 18+
+- Optional: `.env` file in this directory for API keys and overrides
 
-This script generates Text-to-Speech (TTS) audio files for the example words used in the Phonix application. It uses the [ElevenLabs API](https://elevenlabs.io/) to create high-quality audio for each unique word found in the shared phonemes data.
-
-**How It Works:**
-
-1.  **Extracts Words**: It gathers a unique list of all example words from the `shared-data` package (consonants, vowels, and allophones).
-2.  **Generates Audio**: It iterates through the list of words and uses the ElevenLabs API to generate an MP3 audio file for each one.
-3.  **Saves Files**: The generated `.mp3` files are saved to the `apps/web/public/audio/examples/` directory, making them available to the frontend application.
-
-### 2. CMUDict JSON Generation
-
-This script downloads the CMU Pronouncing Dictionary and converts it to a compact JSON format for use by the API. The generated JSON file can be bundled with the application for fast dictionary lookups.
-
-**How It Works:**
-
-1.  **Fetches Data**: Downloads the CMUDict data from a configurable URL (set via `CMUDICT_SRC_URL` environment variable).
-2.  **Processes Entries**: Parses the dictionary format and handles multiple pronunciations for each word.
-3.  **Generates JSON**: Creates a compact JSON file with optimized format for fast API lookups (complete dataset with 130,000+ words).
-4.  **Saves File**: Outputs to `apps/web/public/data/cmudict.json` for bundling with the Next.js application.
-
-## Setup
-
-1. **Install Dependencies**: From the root of the monorepo, run:
-    ```bash
-    pnpm install
-    ```
-
-## Usage
-
-### TTS Audio Generation
-
-To generate the audio files, you need an ElevenLabs API key. Create a `.env` file in this directory (`packages/helper-scripts/.env`) and add your key:
-
-```
-ELEVENLABS_API_KEY=your_api_key_here
-```
-
-Then run:
-```bash
-pnpm run --filter helper-scripts generate
-```
-
-The script will process all unique words and save the corresponding `.mp3` files to `apps/web/public/audio/examples/`.
-
-#### Generating a Sample (TTS)
-
-For testing or development, you can modify the `generate.ts` script to process only a small sample of words. Locate the following line:
-
-```typescript
-const words = extractExampleWords();
-```
-
-And modify it to select a few words, for example:
-
-```typescript
-const words = extractExampleWords().slice(0, 3);
-```
-
-### CMUDict JSON Generation
-
-To generate the CMUDict JSON file, you need to set up the source URL. Create a `.env` file in this directory (`packages/helper-scripts/.env`) with:
-
-```
+```ini
+# packages/helper-scripts/.env
+ELEVENLABS_API_KEY=...
 CMUDICT_SRC_URL=https://raw.githubusercontent.com/rigomart/cmudict/refs/heads/master/cmudict.dict
+# CMUDICT_JSON_PATH=/absolute/or/relative/path.json   # optional override
 ```
 
-Optionally, you can specify a custom output path:
-```
-CMUDICT_JSON_PATH=/path/to/your/custom/location.json
-```
+## Available commands
 
-Then run:
 ```bash
-pnpm run --filter helper-scripts cmudict-to-json
+pnpm -C packages/helper-scripts lint            # biome check --write
+pnpm -C packages/helper-scripts check-types     # tsc --noEmit
+pnpm -C packages/helper-scripts generate        # ElevenLabs example audio generation
+pnpm -C packages/helper-scripts cmudict-to-json # Download & compact CMUDict into JSON
 ```
 
-The script will download the CMUDict data and save it as a JSON file for use by the API.
+## Audio generation workflow
 
+`generate.ts` scans the shared phoneme metadata for unique example words and creates `.mp3` files using the ElevenLabs API.
+
+1. Supply an `ELEVENLABS_API_KEY` in `.env`.
+2. Run `pnpm -C packages/helper-scripts generate`.
+3. Audio is written to `apps/web/public/audio/examples/<word>.mp3` (directories are created automatically).
+
+The script skips words that already have audio. To experiment with a smaller batch, temporarily adjust the `extractExampleWords()` call inside `src/generate.ts`.
+
+## CMUDict JSON workflow
+
+`cmudict-to-json.ts` downloads the raw CMU Pronouncing Dictionary, normalizes entries, and writes a compact JSON map used by the web API.
+
+1. Configure `CMUDICT_SRC_URL` (see `.env` example above).
+2. Optionally set `CMUDICT_JSON_PATH`; otherwise the output defaults to `apps/web/data/cmudict.json`.
+3. Run `pnpm -C packages/helper-scripts cmudict-to-json`.
+
+Logs include entry counts, skipped lines, and file size so you can confirm the generated dictionary before committing it.

--- a/packages/shared-data/README.md
+++ b/packages/shared-data/README.md
@@ -1,130 +1,74 @@
-# Shared Data Package
+# Shared Data
 
-This package contains shared TypeScript data structures and phoneme definitions for the Phonix project.
+This package defines the canonical phoneme catalog, articulation metadata, and helper utilities consumed by both the web application and helper scripts.
 
-## Structure
-
-Exports:
-
-- `consonants.ts` – 24 consonant phonemes (with allophones where pedagogically useful)
-- `vowels.ts` – 16 vowel phonemes (10 monophthongs, 5 diphthongs, 1 rhotic vowel)
-- `articulation.ts` – Pedagogical metadata arrays: `articulationPlaces`, `articulationManners`
-- `types.ts` – Type definitions (phonemes + articulation metadata interfaces)
-- `utils/` – Helpers (`audio.ts`, `ipa.ts`, `slug.ts`)
-- `index.ts` – Barrel exports (data, utilities, types)
-
-### Phoneme List (40 Total)
-
-**Consonants (24)**
-
-- **Stops:** /p/, /b/, /t/, /d/, /k/, /ɡ/
-- **Affricates:** /tʃ/, /dʒ/
-- **Fricatives:** /f/, /v/, /θ/, /ð/, /s/, /z/, /ʃ/, /ʒ/, /h/
-- **Nasals:** /m/, /n/, /ŋ/
-- **Liquids:** /l/, /ɹ/
-- **Glides:** /j/, /w/
-
-**Vowels (16)**
-
-- **Monophthongs (10):**
-  - **High:** /i/, /ɪ/, /u/, /ʊ/
-  - **Mid:** /ɛ/, /ə/, /ʌ/, /ɔ/
-  - **Low:** /æ/, /ɑ/
-  - **Rhotic:** /ɝ/ (with /ɚ/ allophone)
-
-- **Diphthongs (5):** /eɪ/, /aɪ/, /ɔɪ/, /aʊ/, /oʊ/
-
-## Data Structure
-
-Each phoneme object includes:
-
-- **Symbol**: IPA phoneme symbol
-- **Category**: `consonant` or `vowel`
-- **Type**: Specific categorization (e.g., `stop`, `fricative`, `monophthong`, `diphthong`)
-- **Articulation**: Detailed phonetic properties
-  - For consonants: `place`, `manner`, `voicing`
-  - For vowels: `height`, `frontness`, `roundness`, `tenseness`, `rhoticity` (if applicable)
-- **Examples**: Array of example words with phonemic transcriptions (no surrounding slashes). Use `getExampleAudioUrl(word)` to derive audio paths.
-- **Description**: Human-readable phonetic description
-- **Guide**: Pronunciation guidance for learners
-- **Allophones**: Contextual variants (where applicable)
-
-## Usage
+## Exports at a glance
 
 ```ts
 import {
   consonants,
   vowels,
-  articulationPlaces,
-  articulationManners,
+  articulationRegistry,
+  consonantArticulationRegistry,
+  vowelArticulationRegistry,
+  PHONEME_CATEGORIES,
+  getCategoryInfo,
   phonixUtils,
   type ConsonantPhoneme,
-} from 'shared-data';
-
-const stops = consonants.filter(c => c.articulation.manner === 'stop');
-const alveolarMeta = articulationPlaces.find(p => p.key === 'alveolar');
-const audioUrl = phonixUtils.getExampleAudioUrl('make'); // /audio/examples/make.mp3
-const shown = phonixUtils.toPhonemic('bʌt'); // "/bʌt/"
+  type VowelPhoneme,
+} from "shared-data";
 ```
 
-### Articulation Metadata Shapes
+### Core modules
 
-Place entry:
+| Module | Purpose |
+| --- | --- |
+| `src/consonants.ts` | 24 consonant phonemes (with pedagogical allophones where useful). |
+| `src/vowels.ts` | 16 vowel phonemes (10 monophthongs, 5 diphthongs, 1 rhotic vowel). |
+| `src/articulation.ts` | Registries describing articulation places, manners, and vowel dimensions. |
+| `src/category-config.ts` | Category groupings and helpers for chart organization. |
+| `src/utils/` | Utility helpers: audio path builders, IPA formatting, slug helpers, etc. |
+| `src/types.ts` | Strongly-typed interfaces for phonemes, articulation metadata, and example words. |
+| `src/index.ts` | Barrel that exposes the modules above to consumers. |
+
+## Phoneme structure
+
+Every phoneme entry shares a common schema:
+
 ```ts
-interface ArticulationPlaceInfo {
-  key: 'bilabial' | 'labiodental' | ...;
-  label: string;
-  short: string; // <= ~80 chars for tooltips
-  description: string; // longer paragraph
-  how: string[]; // ordered production steps
-  articulators: string[];
-  commonExamples: string[]; // representative symbols
-  diagram?: string; // asset slug (future)
-  order: number;
+interface BasePhoneme {
+  symbol: string;              // IPA symbol, no slashes
+  category: "consonant" | "vowel";
+  type: string;                // e.g. "stop", "monophthong"
+  description: string;         // pedagogical summary
+  guide: string;               // learner-facing production tips
+  examples: ExampleWord[];     // see below
+  allophones?: Allophone[];    // optional contextual variants
+}
+
+interface ExampleWord {
+  word: string;                // orthographic form (lowercase)
+  ipa: string;                 // transcription without surrounding slashes
 }
 ```
 
-Manner entry:
-```ts
-interface ArticulationMannerInfo {
-  key: 'stop' | 'fricative' | ...;
-  label: string;
-  short: string;
-  description: string;
-  how: string[];
-  airflow?: string;
-  commonExamples: string[];
-  order: number;
-}
-```
+Utilities such as `phonixUtils.getExampleAudioUrl(word)` and `phonixUtils.toPhonemic(ipa)` keep formatting consistent between packages.
 
-## Pedagogical Design Principles
+## Adding or updating phonemes
 
-### Example Word Selection
+1. Update the relevant source file (`consonants.ts`, `vowels.ts`, or articulation registries).
+2. Ensure examples are high-frequency, learner-friendly words and store IPA transcriptions without surrounding slashes.
+3. When introducing new metadata fields, extend the interfaces in `types.ts` and re-export them via `src/index.ts`.
+4. Run package checks:
+   ```bash
+   pnpm -C packages/shared-data lint
+   pnpm -C packages/shared-data check-types
+   ```
+5. If example words change, regenerate ElevenLabs audio so the frontend stays in sync.
 
-All example words have been carefully chosen to be **practical and high-frequency** for intermediate-advanced ESL learners:
+## Design principles
 
-- **Essential communication**: Function words like "the", "and", "with", "can"
-- **Daily vocabulary**: Common words like "time", "get", "want", "need", "work"
-- **Practical contexts**: Words useful in everyday conversations and situations
-- **Cognitive load reduction**: Familiar vocabulary that doesn't distract from phoneme focus
-
-### Transcription Philosophy
-
-The transcription system balances phonetic accuracy with pedagogical effectiveness:
-
-- **`/ɹ/` vs. `/r/`**: We use `/ɹ/` for phonetic accuracy in representing the American English rhotic consonant
-- **`/ɡ/` vs. `/g/`**: We use `/ɡ/` (IPA voiced velar stop) rather than `/g/` to maintain IPA standard compliance
-- **No stored slashes**: Example transcriptions are stored without slashes (e.g., `bʌt`). The UI can add slashes when rendering.
-- **Allophone inclusion**: Only pedagogically significant allophones are included:
-  - **Flap /ɾ/**: For /t/ and /d/ in intervocalic positions (e.g., "better")
-  - **Glottal stop /ʔ/**: For /t/ before syllabic nasals (e.g., "button")  
-  - **Dark L /ɫ/**: For /l/ in syllable-final position (e.g., "will")
-  - **Unstressed /ɚ/**: For /ɝ/ in unstressed syllables (e.g., "after")
-
-### ESL Learning Focus
-
-- **Meaning-distinguishing sounds**: Emphasis on phonemes that affect intelligibility
-- **American English (General American)**: Consistent accent model for learners
-- **Intermediate-Advanced level**: Assumes basic English vocabulary knowledge
-- **Pronunciation improvement**: Systematic approach to accent reduction and clarity
+- **Pedagogical focus** – Content targets intermediate-to-advanced ESL learners aiming for General American intelligibility.
+- **Consistent IPA** – `/ɹ/` and `/ɡ/` are used for accuracy; slashes are added at render time, not stored in data.
+- **Meaningful allophones** – Only contextually important variants are included (e.g., flap /ɾ/, glottal stop /ʔ/, dark /ɫ/).
+- **Reusability** – Utilities and registries are structured for cross-package consumption (web UI, helper scripts, future tooling).


### PR DESCRIPTION
## Summary
- rewrite the root README with updated highlights, workspace commands, and helper script guidance
- expand the web app README with current feature, directory, and data dependency details
- document the docs, helper-scripts, and shared-data packages so new contributors can quickly orient

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d0a14804048327bfa9cb7fa8699dd9