### PR TITLE
refactor(web): simplify header mobile nav

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -30,7 +30,7 @@ export function Header() {
 								</Badge>
 							</span>
 						</Link>
-						
+
 						<nav className="hidden items-center gap-1 md:flex">
 							{navigationLinks.map((link) => (
 								<Link
@@ -44,8 +44,7 @@ export function Header() {
 						</nav>
 					</div>
 
-						<ModeToggle />
-		
+					<ModeToggle />
 				</div>
 				<nav className="mt-3 flex gap-2 overflow-x-auto md:hidden">
 					{navigationLinks.map((link) => (


### PR DESCRIPTION
## Summary
- remove the sheet-based mobile navigation from the header and keep it a server component
- present navigation and the minimal pairs CTA inline across breakpoints with overflow scrolling on mobile

## Testing
- pnpm lint *(fails: packages/shared-data lint cannot reach npm registry from the container)*
- pnpm check-types *(fails: packages/shared-data check-types cannot reach npm registry from the container)*
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d0d8df9150832799b8abb58a25e22d