### PR TITLE
fix(minimal-pairs): update phoneme representations and descriptions for accuracy

### DIFF
--- a/docs/enhancements/g2p-plan.md
+++ b/docs/enhancements/g2p-plan.md
@@ -58,7 +58,7 @@ A high-level plan to make the G2P (grapheme-to-phoneme) system fast, accurate, a
 - **Value:**
   ```json
   {
-    "ipa": ["ˈrɛkərd", "rɪˈkɔːrd"],
+    "ipa": ["ˈrɛkərd", "rɪˈkɔrd"],
     "posHints": ["N", "V"],
     "notes": { "special": "the_variant", "freqRank": 5234 }
   }
@@ -73,7 +73,7 @@ A high-level plan to make the G2P (grapheme-to-phoneme) system fast, accurate, a
 - Lowercase except for proper nouns (leading cap after sentence boundary).
 - Strip punctuation; handle possessives and hyphens.
 - Convert numbers and dates to words before G2P.
-- Acronyms: ALL-CAPS (length ≥ 2) → letter names (A = eɪ, B = biː, etc.), plus special cases (NASA, SQL).
+- Acronyms: ALL-CAPS (length ≥ 2) → letter names (A = eɪ, B = bi, etc.), plus special cases (NASA, SQL).
 
 ### 2. Morphological Handling (Before Rules)
 - Try base forms: remove -s/-es, -ed, -ing, -er/-est, -’s; apply e-dropping, y→i rules.
@@ -92,10 +92,10 @@ A high-level plan to make the G2P (grapheme-to-phoneme) system fast, accurate, a
   - x → ks generally, gz before stressed vowel onset in some contexts (e.g., "exact").
   - s → z between vowels.
   - y as vowel in syllable nucleus (ɪ/i), y as consonant at onset (j).
-  - magic-e: a_e → eɪ, i_e → aɪ (or iː in some systems), o_e → oʊ, u_e → juː/uː contextually.
+  - magic-e: a_e → eɪ, i_e → aɪ (or i in some systems), o_e → oʊ, u_e → ju/u contextually.
   - gh: silent in most environments; -ough pattern list (though/through/rough/ought/cough/borough).
   - kn-/wr- initial letter silent; mb final b silent; lk/lt after a → l often dark but keep /l/.
-  - qu → kw; wh → w in GA (except "who" → huː).
+  - qu → kw; wh → w in GA (except "who" → hu).
 
 ### 4. Syllabification and Stress Heuristics
 - Sonority-based syllable parsing with maximal onset.

--- a/docs/features/minimal-pairs.md
+++ b/docs/features/minimal-pairs.md
@@ -1,6 +1,6 @@
 # Minimal Pairs Feature Development Plan
 
-This document outlines the phased development plan for the Minimal Pairs feature in Phonix, an interactive pronunciation learning platform for ESL learners. The feature focuses on phoneme-level mastery by helping users distinguish and practice similar sounds (e.g., /ɪ/ vs. /iː/ in "ship" vs. "sheep"). Each phase delivers a functional, iterable product, progressing from core functionality to advanced enhancements, integrating with existing IPA chart and G2P transcription tools. The plan prioritizes a phoneme-first approach, interactive discovery, and evidence-based ESL practices.
+This document outlines the phased development plan for the Minimal Pairs feature in Phonix, an interactive pronunciation learning platform for ESL learners. The feature focuses on phoneme-level mastery by helping users distinguish and practice similar sounds (e.g., /ɪ/ vs. /i/ in "ship" vs. "sheep"). Each phase delivers a functional, iterable product, progressing from core functionality to advanced enhancements, integrating with existing IPA chart and G2P transcription tools. The plan prioritizes a phoneme-first approach, interactive discovery, and evidence-based ESL practices.
 
 ## Phase 1: Core Listening Discrimination
 
@@ -9,7 +9,7 @@ Create a foundational tool for users to compare and distinguish minimal pairs th
 
 ### Access Points
 - **Navbar Link**: Add "Minimal Pairs" to the app's top-level navigation, alongside "IPA Chart" and "G2P Tool," for direct access to the feature.
-- **Phoneme Details**: In the IPA chart or G2P analysis phoneme detail views, include a "Differentiate with X" section listing 2-3 common contrasts (e.g., for /ɪ/, suggest /iː/ with "ship/sheep"), with buttons to launch focused pair sessions.
+- **Phoneme Details**: In the IPA chart or G2P analysis phoneme detail views, include a "Differentiate with X" section listing 2-3 common contrasts (e.g., for /ɪ/, suggest /i/ with "ship/sheep"), with buttons to launch focused pair sessions.
 
 ### Core Functionality
 - **Predefined Pair Sets**: Curate 20-30 minimal pairs, categorized by contrast type (vowels, consonants) and searchable via dropdowns on the Minimal Pairs page.

--- a/packages/shared-data/src/minimal-pairs.ts
+++ b/packages/shared-data/src/minimal-pairs.ts
@@ -5,12 +5,12 @@ export const minimalPairSets: MinimalPairSet[] = [
 	{
 		id: "vowel-short-long-i",
 		slug: "short-i-vs-long-ee",
-		title: "/ɪ/ vs /iː/: Ship vs. Sheep",
+		title: "/ɪ/ vs /i/: Ship vs. Sheep",
 		category: "vowel",
-		focusPhonemes: ["ɪ", "iː"],
-		summary: "Contrast the relaxed short /ɪ/ with the tense, lengthened /iː/",
+		focusPhonemes: ["ɪ", "i"],
+		summary: "Contrast the relaxed short /ɪ/ with the tense, lengthened /i/",
 		description:
-			"Keep the tongue high at the front for both vowels, but shorten and relax /ɪ/ while lengthening /iː/ with tighter lips.",
+			"Keep the tongue high at the front for both vowels, but shorten and relax /ɪ/ while lengthening /i/ with tighter lips.",
 		tags: ["front vowels", "length", "common ESL"],
 		difficulty: "foundational",
 		l1Notes:
@@ -22,7 +22,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				details: "Tongue sits high and front but remains relaxed and brief with neutral lips.",
 			},
 			{
-				phoneme: "iː",
+				phoneme: "i",
 				headline: "Tense high front vowel",
 				details: "Raise the tongue fully high-front, spread the lips, and sustain the vowel.",
 			},
@@ -43,7 +43,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "sheep",
-						phonemic: "ʃiːp",
+						phonemic: "ʃip",
 						graphemeHint: "ee",
 						audioUrl: getExampleAudioUrl("sheep"),
 						pronunciationTip: "Hold the vowel slightly longer with a smile shape.",
@@ -64,7 +64,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "leave",
-						phonemic: "liːv",
+						phonemic: "liv",
 						graphemeHint: "ea",
 						audioUrl: getExampleAudioUrl("leave"),
 					},
@@ -73,7 +73,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 			{
 				id: "sit-seat",
 				contrastLabel: "short vs. long vowel",
-				description: "Listen for the clipped /ɪ/ compared with the gliding /iː/.",
+				description: "Listen for the clipped /ɪ/ compared with the gliding /i/.",
 				practiceNote: "Touch the top teeth lightly for the final /t/ to keep timing even.",
 				words: [
 					{
@@ -84,7 +84,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "seat",
-						phonemic: "siːt",
+						phonemic: "sit",
 						graphemeHint: "ea",
 						audioUrl: getExampleAudioUrl("seat"),
 					},
@@ -105,7 +105,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "leek",
-						phonemic: "liːk",
+						phonemic: "lik",
 						graphemeHint: "ee",
 						audioUrl: getExampleAudioUrl("leek"),
 					},
@@ -125,7 +125,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "feel",
-						phonemic: "fiːl",
+						phonemic: "fil",
 						graphemeHint: "ee",
 						audioUrl: getExampleAudioUrl("feel"),
 					},
@@ -264,12 +264,12 @@ export const minimalPairSets: MinimalPairSet[] = [
 	{
 		id: "vowel-pull-pool",
 		slug: "pull-vs-pool",
-		title: "/ʊ/ vs /uː/: Pull vs. Pool",
+		title: "/ʊ/ vs /u/: Pull vs. Pool",
 		category: "vowel",
-		focusPhonemes: ["ʊ", "uː"],
-		summary: "Contrast the short rounded /ʊ/ with the long, tense /uː/",
+		focusPhonemes: ["ʊ", "u"],
+		summary: "Contrast the short rounded /ʊ/ with the long, tense /u/",
 		description:
-			"Both vowels require rounded lips, but /ʊ/ is shorter with a central tongue, while /uː/ is longer with a tighter high-back position.",
+			"Both vowels require rounded lips, but /ʊ/ is shorter with a central tongue, while /u/ is longer with a tighter high-back position.",
 		tags: ["back vowels", "length", "rounded"],
 		difficulty: "intermediate",
 		l1Notes: "Germanic learners often over-tense /ʊ/, while Romance speakers merge toward /u/.",
@@ -280,7 +280,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				details: "Rounded lips but keep the tongue slightly lower and central.",
 			},
 			{
-				phoneme: "uː",
+				phoneme: "u",
 				headline: "Long tense back vowel",
 				details: "Round firmly, pull the tongue high and back, and sustain.",
 			},
@@ -301,7 +301,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "pool",
-						phonemic: "puːl",
+						phonemic: "pul",
 						graphemeHint: "oo",
 						audioUrl: getExampleAudioUrl("pool"),
 					},
@@ -311,7 +311,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				id: "full-fool",
 				contrastLabel: "short vs. long rounded vowel",
 				description: "Same consonants across both syllables—listen for vowel core.",
-				practiceNote: "Avoid diphthongizing /uː/.",
+				practiceNote: "Avoid diphthongizing /u/.",
 				words: [
 					{
 						word: "full",
@@ -321,7 +321,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "fool",
-						phonemic: "fuːl",
+						phonemic: "ful",
 						graphemeHint: "oo",
 						audioUrl: getExampleAudioUrl("fool"),
 					},
@@ -331,7 +331,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				id: "foot-food",
 				contrastLabel: "short vs. long rounded vowel",
 				description: "One of the most frequent listening confusions for English learners.",
-				practiceNote: "Keep /uː/ steady—no glide toward /ʊ/.",
+				practiceNote: "Keep /u/ steady—no glide toward /ʊ/.",
 				words: [
 					{
 						word: "foot",
@@ -341,7 +341,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "food",
-						phonemic: "fuːd",
+						phonemic: "fud",
 						graphemeHint: "oo",
 						audioUrl: getExampleAudioUrl("food"),
 					},
@@ -351,7 +351,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				id: "could-cooed",
 				contrastLabel: "short vs. long rounded vowel",
 				description: "Spelling stays the same—only vowel length signals the meaning.",
-				practiceNote: "Keep /ʊ/ central; pull /uː/ farther back.",
+				practiceNote: "Keep /ʊ/ central; pull /u/ farther back.",
 				words: [
 					{
 						word: "could",
@@ -361,7 +361,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "cooed",
-						phonemic: "kuːd",
+						phonemic: "kud",
 						graphemeHint: "oo",
 						audioUrl: getExampleAudioUrl("cooed"),
 					},
@@ -371,7 +371,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 				id: "pull-peel",
 				contrastLabel: "rounded vs. unrounded",
 				description: "A bonus contrast mixing vowel quality and length cues.",
-				practiceNote: "Feel the lips relax for the /iː/ in peel.",
+				practiceNote: "Feel the lips relax for the /i/ in peel.",
 				words: [
 					{
 						word: "pull",
@@ -381,7 +381,7 @@ export const minimalPairSets: MinimalPairSet[] = [
 					},
 					{
 						word: "peel",
-						phonemic: "piːl",
+						phonemic: "pil",
 						graphemeHint: "ee",
 						audioUrl: getExampleAudioUrl("peel"),
 					},


### PR DESCRIPTION
This commit corrects the phoneme representations in the minimal pairs feature, changing instances of /iː/ to /i/ and updating related descriptions for clarity. Adjustments were made to ensure consistency across the minimal pairs data structure, enhancing the learning experience for ESL users.