### PR TITLE
Rename stop labels to plosive terminology

### DIFF
--- a/apps/web/src/app/[locale]/ipa-chart/_lib/consonant-grid.ts
+++ b/apps/web/src/app/[locale]/ipa-chart/_lib/consonant-grid.ts
@@ -12,7 +12,7 @@ export type Voicing = ConsonantArticulatoryFeatures["voicing"];
  * Groups similar sounds together: plosives first, then continuants
  */
 export const MANNER_ORDER: MannerOfArticulation[] = [
-	"stop",
+	"plosive",
 	"nasal",
 	"fricative",
 	"affricate",
@@ -40,7 +40,7 @@ export const PLACE_ORDER: PlaceOfArticulation[] = [
  * Human-readable labels for manner of articulation
  */
 export const MANNER_LABELS: Record<MannerOfArticulation, string> = {
-	stop: "Stop",
+	plosive: "Plosive",
 	nasal: "Nasal",
 	fricative: "Fricative",
 	affricate: "Affricate",

--- a/apps/web/src/app/api/g2p/_core/dictionary.ts
+++ b/apps/web/src/app/api/g2p/_core/dictionary.ts
@@ -63,7 +63,7 @@ class CMUDict {
 			if (tokens.length === 0) continue;
 
 			const mappedVariant: G2PPhoneme[] = tokens.map((token) => {
-				const symbolId = getSymbolIdForCmuToken(token); // e.g. "voiceless-bilabial-stop"
+				const symbolId = getSymbolIdForCmuToken(token); // e.g. "voiceless-bilabial-plosive"
 
 				if (!symbolId) {
 					return {

--- a/apps/web/src/data/phoneme-details.ts
+++ b/apps/web/src/data/phoneme-details.ts
@@ -33,8 +33,8 @@ export type PhonemeDetailsEntry = {
 
 // TODO: Refine pitfalls and steps before wiring to the UI
 export const phonemeDetailsById: Record<PhonemeSymbolId, PhonemeDetailsEntry> = {
-	"voiceless-bilabial-stop": {
-		label: "Voiceless bilabial stop",
+	"voiceless-bilabial-plosive": {
+		label: "Voiceless bilabial plosive",
 		pitfalls: [
 			{
 				summary: "No puff at start",
@@ -46,11 +46,11 @@ export const phonemeDetailsById: Record<PhonemeSymbolId, PhonemeDetailsEntry> = 
 			},
 		],
 	},
-	"voiced-bilabial-stop": {
-		label: "Voiced bilabial stop",
+	"voiced-bilabial-plosive": {
+		label: "Voiced bilabial plosive",
 	},
-	"voiceless-alveolar-stop": {
-		label: "Voiceless alveolar stop",
+	"voiceless-alveolar-plosive": {
+		label: "Voiceless alveolar plosive",
 		pitfalls: [
 			{
 				summary: "No puff at start",
@@ -62,14 +62,14 @@ export const phonemeDetailsById: Record<PhonemeSymbolId, PhonemeDetailsEntry> = 
 			},
 		],
 	},
-	"voiced-alveolar-stop": {
-		label: "Voiced alveolar stop",
+	"voiced-alveolar-plosive": {
+		label: "Voiced alveolar plosive",
 	},
-	"voiced-velar-stop": {
-		label: "Voiced velar stop",
+	"voiced-velar-plosive": {
+		label: "Voiced velar plosive",
 	},
-	"voiceless-velar-stop": {
-		label: "Voiceless velar stop",
+	"voiceless-velar-plosive": {
+		label: "Voiceless velar plosive",
 		pitfalls: [
 			{
 				summary: "Sounds like /g/",
@@ -515,8 +515,8 @@ export const featureDefinitions: BaseFeatureDefinitions = {
 		label: "Manner",
 		description: "How airflow is modified to produce the sound",
 		values: {
-			stop: {
-				label: "Stop",
+			plosive: {
+				label: "Plosive",
 				description: "Airflow fully stops then releases in a burst.",
 			},
 			fricative: {

--- a/packages/shared-data/src/articulation.ts
+++ b/packages/shared-data/src/articulation.ts
@@ -69,9 +69,9 @@ export const consonantArticulationRegistry: Record<string, ArticulationEntry> = 
 	},
 
 	// Manners
-	stop: {
-		key: "stop",
-		label: "Stop (Plosive)",
+	plosive: {
+		key: "plosive",
+		label: "Plosive",
 		short: "Complete closure then release of airflow.",
 		airflow: "Blocked then released explosively.",
 		category: "Manner",

--- a/packages/shared-data/src/category-config.ts
+++ b/packages/shared-data/src/category-config.ts
@@ -16,9 +16,9 @@ export interface CategoryConfig {
  */
 export const PHONEME_CATEGORIES: CategoryConfig = {
 	consonant: {
-		stop: {
-			key: "stop",
-			label: "Stops",
+		plosive: {
+			key: "plosive",
+			label: "Plosives",
 			description: "Complete blockage then release",
 			order: 1,
 		},

--- a/packages/shared-data/src/phonetics/cmu-lookup.ts
+++ b/packages/shared-data/src/phonetics/cmu-lookup.ts
@@ -6,12 +6,12 @@ import type { PhonemeSymbolId } from "./symbols-registry";
  */
 export const CmuSymbolRegistry = {
 	// Consonants
-	P: "voiceless-bilabial-stop",
-	B: "voiced-bilabial-stop",
-	T: "voiceless-alveolar-stop",
-	D: "voiced-alveolar-stop",
-	K: "voiceless-velar-stop",
-	G: "voiced-velar-stop",
+	P: "voiceless-bilabial-plosive",
+	B: "voiced-bilabial-plosive",
+	T: "voiceless-alveolar-plosive",
+	D: "voiced-alveolar-plosive",
+	K: "voiceless-velar-plosive",
+	G: "voiced-velar-plosive",
 	F: "voiceless-labiodental-fricative",
 	V: "voiced-labiodental-fricative",
 	TH: "voiceless-dental-fricative",
@@ -90,7 +90,7 @@ export type CmuArpaToken = keyof typeof CmuSymbolRegistry;
  * @param token - The CMU ARPA token string to map.
  * @returns The phoneme symbol ID, or undefined if the token is not found.
  * @example
- * getSymbolIdForCmuToken("R") // "voiceless-bilabial-stop"
+ * getSymbolIdForCmuToken("P") // "voiceless-bilabial-plosive"
  * getSymbolIdForCmuToken("AH0") // "open-mid-back-unrounded"
  * getSymbolIdForCmuToken("UNKNOWN") // undefined
  */

--- a/packages/shared-data/src/phonetics/phoneme-allophones.ts
+++ b/packages/shared-data/src/phonetics/phoneme-allophones.ts
@@ -12,8 +12,8 @@ type BasePhonemeAllophone<ContextKey extends string = string> = {
 };
 
 const phonemeAllophonesData = {
-	// Voiceless stops: aspiration vs s-clusters; plus key /t/ variants
-	"voiceless-bilabial-stop": [
+	// Voiceless plosives: aspiration vs s-clusters; plus key /t/ variants
+	"voiceless-bilabial-plosive": [
 		{
 			ipaVariant: "pʰ",
 			contextKey: "stressed-onset-aspirated",
@@ -31,7 +31,7 @@ const phonemeAllophonesData = {
 			],
 		},
 	],
-	"voiceless-alveolar-stop": [
+	"voiceless-alveolar-plosive": [
 		{
 			ipaVariant: "tʰ",
 			contextKey: "stressed-onset-aspirated",
@@ -57,7 +57,7 @@ const phonemeAllophonesData = {
 			],
 		},
 	],
-	"voiceless-velar-stop": [
+	"voiceless-velar-plosive": [
 		{
 			ipaVariant: "kʰ",
 			contextKey: "stressed-onset-aspirated",

--- a/packages/shared-data/src/phonetics/phoneme-articulations.ts
+++ b/packages/shared-data/src/phonetics/phoneme-articulations.ts
@@ -23,29 +23,29 @@ type PhonemeArticulationBase<
 type ConsonantArticulation = PhonemeArticulationBase<"consonant", ConsonantArticulatoryFeatures>;
 
 export const ConsonantArticulationRegistry: Record<ConsonantSymbolId, ConsonantArticulation> = {
-	"voiceless-bilabial-stop": {
+	"voiceless-bilabial-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "bilabial", voicing: "voiceless" },
+		features: { manner: "plosive", place: "bilabial", voicing: "voiceless" },
 	},
-	"voiced-bilabial-stop": {
+	"voiced-bilabial-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "bilabial", voicing: "voiced" },
+		features: { manner: "plosive", place: "bilabial", voicing: "voiced" },
 	},
-	"voiceless-alveolar-stop": {
+	"voiceless-alveolar-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "alveolar", voicing: "voiceless" },
+		features: { manner: "plosive", place: "alveolar", voicing: "voiceless" },
 	},
-	"voiced-alveolar-stop": {
+	"voiced-alveolar-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "alveolar", voicing: "voiced" },
+		features: { manner: "plosive", place: "alveolar", voicing: "voiced" },
 	},
-	"voiced-velar-stop": {
+	"voiced-velar-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "velar", voicing: "voiced" },
+		features: { manner: "plosive", place: "velar", voicing: "voiced" },
 	},
-	"voiceless-velar-stop": {
+	"voiceless-velar-plosive": {
 		category: "consonant",
-		features: { manner: "stop", place: "velar", voicing: "voiceless" },
+		features: { manner: "plosive", place: "velar", voicing: "voiceless" },
 	},
 	"voiced-dental-fricative": {
 		category: "consonant",

--- a/packages/shared-data/src/phonetics/phoneme-contrasts.ts
+++ b/packages/shared-data/src/phonetics/phoneme-contrasts.ts
@@ -13,7 +13,7 @@ type PhonemeContrastPair = {
 type PhonemeContrastType = keyof ConsonantArticulatoryFeatures | keyof VowelArticulatoryFeatures;
 
 export type PhonemeContrast = {
-	phonemeIds: [PhonemeSymbolId, PhonemeSymbolId]; // The pair. e.g. ["voiced-bilabial-stop", "voiced-labiodental-fricative"]
+	phonemeIds: [PhonemeSymbolId, PhonemeSymbolId]; // The pair. e.g. ["voiced-bilabial-plosive", "voiced-labiodental-fricative"]
 	contrastType: PhonemeArticulatoryFeatureKey[]; // Usually one, but can be multiple. e.g. ["manner", "place"]
 	minimalPairs: [PhonemeContrastPair, PhonemeContrastPair][];
 };
@@ -22,7 +22,7 @@ export type PhonemeContrast = {
 export const PhonemeContrastCatalog: PhonemeContrast[] = [
 	// Consonants: Voicing
 	{
-		phonemeIds: ["voiceless-bilabial-stop", "voiced-bilabial-stop"],
+		phonemeIds: ["voiceless-bilabial-plosive", "voiced-bilabial-plosive"],
 		contrastType: ["voicing"],
 		minimalPairs: [
 			[
@@ -36,7 +36,7 @@ export const PhonemeContrastCatalog: PhonemeContrast[] = [
 		],
 	},
 	{
-		phonemeIds: ["voiceless-alveolar-stop", "voiced-alveolar-stop"],
+		phonemeIds: ["voiceless-alveolar-plosive", "voiced-alveolar-plosive"],
 		contrastType: ["voicing"],
 		minimalPairs: [
 			[
@@ -50,7 +50,7 @@ export const PhonemeContrastCatalog: PhonemeContrast[] = [
 		],
 	},
 	{
-		phonemeIds: ["voiceless-velar-stop", "voiced-velar-stop"],
+		phonemeIds: ["voiceless-velar-plosive", "voiced-velar-plosive"],
 		contrastType: ["voicing"],
 		minimalPairs: [
 			[
@@ -136,7 +136,7 @@ export const PhonemeContrastCatalog: PhonemeContrast[] = [
 		],
 	},
 	{
-		phonemeIds: ["voiceless-dental-fricative", "voiceless-alveolar-stop"],
+		phonemeIds: ["voiceless-dental-fricative", "voiceless-alveolar-plosive"],
 		contrastType: ["place", "manner"],
 		minimalPairs: [
 			[
@@ -164,7 +164,7 @@ export const PhonemeContrastCatalog: PhonemeContrast[] = [
 		],
 	},
 	{
-		phonemeIds: ["voiced-dental-fricative", "voiced-alveolar-stop"],
+		phonemeIds: ["voiced-dental-fricative", "voiced-alveolar-plosive"],
 		contrastType: ["place", "manner"],
 		minimalPairs: [
 			[
@@ -262,7 +262,7 @@ export const PhonemeContrastCatalog: PhonemeContrast[] = [
 		],
 	},
 	{
-		phonemeIds: ["voiced-bilabial-stop", "voiced-labiodental-fricative"],
+		phonemeIds: ["voiced-bilabial-plosive", "voiced-labiodental-fricative"],
 		contrastType: ["manner", "place"],
 		minimalPairs: [
 			[

--- a/packages/shared-data/src/phonetics/phoneme-patterns.ts
+++ b/packages/shared-data/src/phonetics/phoneme-patterns.ts
@@ -14,7 +14,7 @@ type SpellingPattern = {
 
 export const PhonemeSpellingPatternRegistry: Partial<Record<PhonemeSymbolId, SpellingPattern>> = {
 	// Consonants
-	"voiceless-velar-stop": {
+	"voiceless-velar-plosive": {
 		patterns: ["ck", "ke", "ki", "ky", "ca", "co", "cu"],
 		examples: [
 			{ word: "back", phonemic: "bæk" },
@@ -22,7 +22,7 @@ export const PhonemeSpellingPatternRegistry: Partial<Record<PhonemeSymbolId, Spe
 			{ word: "cat", phonemic: "kæt" },
 		],
 	},
-	"voiced-velar-stop": {
+	"voiced-velar-plosive": {
 		patterns: ["gue", "gui", "gg"],
 		examples: [
 			{ word: "guest", phonemic: "ɡɛst" },

--- a/packages/shared-data/src/phonetics/symbols-registry.ts
+++ b/packages/shared-data/src/phonetics/symbols-registry.ts
@@ -27,7 +27,7 @@ export type ConsonantArticulatoryFeatures = {
 		| "postalveolar"
 		| "dental"
 		| "alveolar-lateral";
-	manner: "stop" | "fricative" | "affricate" | "nasal" | "approximant";
+	manner: "plosive" | "fricative" | "affricate" | "nasal" | "approximant";
 };
 
 export type ConsonantPhonemeArticulatoryFeatureKey = keyof ConsonantArticulatoryFeatures;
@@ -36,12 +36,12 @@ type ConsonantPhonemeIdPattern =
 	`${ConsonantArticulatoryFeatures["voicing"]}-${ConsonantArticulatoryFeatures["place"]}-${ConsonantArticulatoryFeatures["manner"]}`;
 
 export const ConsonantSymbolRegistry = {
-	"voiceless-bilabial-stop": { ipa: "p", arpa: "P", category: "consonant" },
-	"voiced-bilabial-stop": { ipa: "b", arpa: "B", category: "consonant" },
-	"voiceless-alveolar-stop": { ipa: "t", arpa: "T", category: "consonant" },
-	"voiced-alveolar-stop": { ipa: "d", arpa: "D", category: "consonant" },
-	"voiced-velar-stop": { ipa: "ɡ", arpa: "G", category: "consonant" },
-	"voiceless-velar-stop": { ipa: "k", arpa: "K", category: "consonant" },
+	"voiceless-bilabial-plosive": { ipa: "p", arpa: "P", category: "consonant" },
+	"voiced-bilabial-plosive": { ipa: "b", arpa: "B", category: "consonant" },
+	"voiceless-alveolar-plosive": { ipa: "t", arpa: "T", category: "consonant" },
+	"voiced-alveolar-plosive": { ipa: "d", arpa: "D", category: "consonant" },
+	"voiced-velar-plosive": { ipa: "ɡ", arpa: "G", category: "consonant" },
+	"voiceless-velar-plosive": { ipa: "k", arpa: "K", category: "consonant" },
 	"voiced-dental-fricative": { ipa: "ð", arpa: "DH", category: "consonant" },
 	"voiceless-dental-fricative": { ipa: "θ", arpa: "TH", category: "consonant" },
 	"voiceless-labiodental-fricative": { ipa: "f", arpa: "F", category: "consonant" },


### PR DESCRIPTION
Replace all instances of "stop" with "plosive" in phonetic categorization across the codebase to use more accurate linguistic terminology. Changes include:

- Update ConsonantArticulatoryFeatures manner type from "stop" to "plosive"
- Rename all phoneme IDs: voiceless/voiced-bilabial/alveolar/velar-stop → plosive
- Update category configuration (PHONEME_CATEGORIES)
- Update articulation registry labels and keys
- Update CMU dictionary symbol mappings
- Update IPA chart labels and constants
- Update phoneme detail labels and feature definitions
- Update minimal pairs and contrast references
- Update allophone and spelling pattern registries

All type checking and linting pass successfully.