### PR TITLE
Make header responsive for mobile devices

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,10 +1,16 @@
-import { AudioLines } from "lucide-react";
-import Link from "next/link";
-import { ModeToggle } from "@/components/mode-toggle";
-import { getScopedI18n } from "@/locales/server";
+"use client";
 
-export async function Header() {
-	const t = await getScopedI18n("components.header.navigation");
+import { AudioLines, Menu } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { ModeToggle } from "@/components/mode-toggle";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { useScopedI18n } from "@/locales/client";
+
+export function Header() {
+	const [open, setOpen] = useState(false);
+	const t = useScopedI18n("components.header.navigation");
 
 	const navigationLinks = [
 		{ href: "/overview", label: t("overview") },
@@ -39,20 +45,35 @@ export async function Header() {
 						</nav>
 					</div>
 
-					<ModeToggle />
+					<div className="flex items-center gap-2">
+						<ModeToggle />
+						<Sheet open={open} onOpenChange={setOpen}>
+							<SheetTrigger asChild>
+								<Button variant="ghost" size="icon" className="md:hidden">
+									<Menu className="size-5" />
+									<span className="sr-only">Toggle navigation menu</span>
+								</Button>
+							</SheetTrigger>
+							<SheetContent side="right">
+								<SheetHeader>
+									<SheetTitle>Navigation</SheetTitle>
+								</SheetHeader>
+								<nav className="flex flex-col gap-4 mt-6">
+									{navigationLinks.map((link) => (
+										<Link
+											key={link.href}
+											href={link.href}
+											onClick={() => setOpen(false)}
+											className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+										>
+											{link.label}
+										</Link>
+									))}
+								</nav>
+							</SheetContent>
+						</Sheet>
+					</div>
 				</div>
-
-				<nav className="mt-3 flex gap-3 overflow-x-auto md:hidden">
-					{navigationLinks.map((link) => (
-						<Link
-							key={link.href}
-							href={link.href}
-							className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
-						>
-							{link.label}
-						</Link>
-					))}
-				</nav>
 			</div>
 		</header>
 	);


### PR DESCRIPTION
Replace two-row mobile header layout with single-row design using shadcn/ui Sheet component. The header now features a hamburger menu button on mobile devices that opens a slide-out navigation panel.

Key changes:
- Convert Header to client component to manage Sheet state
- Add hamburger menu (Menu icon) visible only on mobile (md:hidden)
- Use Sheet component for mobile navigation drawer
- Remove second-row navigation that caused layout issues on mobile
- Switch from server-side getScopedI18n to client-side useScopedI18n
- Maintain desktop horizontal navigation as-is