### PR TITLE
Improve explanations for phonetic charts

### DIFF
--- a/apps/web/locales/en/index.ts
+++ b/apps/web/locales/en/index.ts
@@ -72,7 +72,7 @@ export default {
 				description:
 					"Consonant sounds organized by type and characteristics. Click any phoneme for detailed pronunciation information.",
 				diagram:
-					"Side view of how the sound is formed. Look for: place (where airflow narrows), manner (how it narrows or releases), voicing (wavy lines show throat vibration), and nasal airflow (soft palate open for nasals).",
+					"Consonants organized by manner (rows: how the sound is made) and place (columns: where in the mouth). Within each cell: voiceless left, voiced right.",
 			},
 			vowels: {
 				title: "Vowel Phonemes",
@@ -82,12 +82,13 @@ export default {
 					title: "Monophthongs & Rhotic Vowels",
 					description: "Single steady vowels organized by their tongue position.",
 					diagram:
-						"The marker shows the tongue's height (vertical) and position (horizontal) for this vowel.",
+						"Vowels plotted by tongue position. Vertical axis shows tongue height (high to low). Horizontal axis shows tongue backness (front to back).",
 				},
 				diphthongs: {
 					title: "Diphthongs",
 					description: "Two-part vowels that glide from a starting position to an ending position.",
-					diagram: "The two markers show the start and end positions of the diphthong.",
+					diagram:
+						"Vowels that glide between two positions. Each arrow traces the tongue's movement from start to end.",
 				},
 				legend: {
 					rounded: "Rounded",

--- a/apps/web/src/app/[locale]/ipa-chart/_components/chart-info-button.tsx
+++ b/apps/web/src/app/[locale]/ipa-chart/_components/chart-info-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+type ChartInfoButtonProps = {
+	content: string;
+	ariaLabel?: string;
+};
+
+export function ChartInfoButton({
+	content,
+	ariaLabel = "Chart information",
+}: ChartInfoButtonProps) {
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="absolute top-2 right-2 h-7 w-7 text-muted-foreground hover:text-foreground z-10"
+					aria-label={ariaLabel}
+				>
+					<Info className="h-4 w-4" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-80">
+				<p className="text-sm text-foreground leading-relaxed">{content}</p>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/web/src/app/[locale]/ipa-chart/_sections/consonants-section.tsx
+++ b/apps/web/src/app/[locale]/ipa-chart/_sections/consonants-section.tsx
@@ -1,4 +1,5 @@
 import { useScopedI18n } from "@/locales/client";
+import { ChartInfoButton } from "../_components/chart-info-button";
 import { ConsonantChart } from "../_components/consonant-chart";
 
 export function ConsonantsSection() {
@@ -9,10 +10,8 @@ export function ConsonantsSection() {
 				<h2 className="text-xl font-medium">{t("title")}</h2>
 				<p className="text-sm text-muted-foreground">{t("description")}</p>
 			</div>
-			<div className="space-y-3 rounded-lg border bg-background-soft p-1 shadow-sm">
-				<div className="text-xs text-muted-foreground p-2 border rounded-lg bg-accent/10">
-					{t("diagram")}
-				</div>
+			<div className="relative space-y-3 rounded-lg border bg-background-soft p-1 shadow-sm">
+				<ChartInfoButton content={t("diagram")} ariaLabel="How to read the consonant chart" />
 				<ConsonantChart />
 			</div>
 		</div>

--- a/apps/web/src/app/[locale]/ipa-chart/_sections/vowels-section.tsx
+++ b/apps/web/src/app/[locale]/ipa-chart/_sections/vowels-section.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { useScopedI18n } from "@/locales/client";
+import { ChartInfoButton } from "../_components/chart-info-button";
 import { DiphthongVowelChart } from "../_components/diphthong-chart";
 import { MonophthongVowelChart, VowelChartLegend } from "../_components/vowel-chart";
 import type {
@@ -21,6 +22,11 @@ const entriesByVariant: Record<Variant, VowelChartEntry[]> = {
 	diphthongs: diphthongVowelEntries,
 };
 
+const ariaLabelsByVariant: Record<Variant, string> = {
+	monophthongs: "How to read the monophthong vowel chart",
+	diphthongs: "How to read the diphthong vowel chart",
+};
+
 export function VowelChartSection({ variant, className }: Props) {
 	const t = useScopedI18n("ipa-chart.sections.vowels");
 	const entries = entriesByVariant[variant];
@@ -32,10 +38,11 @@ export function VowelChartSection({ variant, className }: Props) {
 				<p className="text-sm text-muted-foreground">{t(`${variant}.description`)}</p>
 			</div>
 			<div className="space-y-3">
-				<div className="rounded-lg border bg-background-soft p-1 shadow-sm">
-					<div className="text-xs text-muted-foreground p-2 border rounded-lg bg-accent/10">
-						{t(`${variant}.diagram`)}
-					</div>
+				<div className="relative rounded-lg border bg-background-soft p-1 shadow-sm">
+					<ChartInfoButton
+						content={t(`${variant}.diagram`)}
+						ariaLabel={ariaLabelsByVariant[variant]}
+					/>
 					{variant === "monophthongs" ? (
 						<MonophthongVowelChart entries={entries as StaticVowelChartEntry[]} />
 					) : (


### PR DESCRIPTION
- Update diagram explanations to be more practical and concise:
  * Consonants: clarify grid organization (manner × place)
  * Monophthongs: explain axes (height × backness)
  * Diphthongs: describe gliding movement with arrows
- Replace always-visible explanation text with info button + popover
- Add reusable ChartInfoButton component for progressive disclosure
- Improve accessibility with descriptive aria-labels

This aligns with the design philosophy of progressive disclosure, reducing visual clutter while keeping help accessible when needed.