### PR TITLE
Analyze URL routing for IPA chart tabs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
 		"next": "15.5.5",
 		"next-international": "^1.3.1",
 		"next-themes": "^0.4.6",
+		"nuqs": "^2.8.0",
 		"react": "19.1.0",
 		"react-dom": "19.1.0",
 		"shared-data": "workspace:*",

--- a/apps/web/src/app/[locale]/ipa-chart/page.tsx
+++ b/apps/web/src/app/[locale]/ipa-chart/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { parseAsStringEnum, useQueryState } from "nuqs";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useScopedI18n } from "@/locales/client";
@@ -7,9 +8,17 @@ import { PhonemeDialog } from "./_components/phoneme-dialog";
 import { ConsonantsSection } from "./_sections/consonants-section";
 import { VowelChartSection } from "./_sections/vowels-section";
 
+const IPA_CHART_TABS = ["monophthongs", "diphthongs", "consonants"] as const;
+type IpaChartTab = (typeof IPA_CHART_TABS)[number];
+
 export default function IpaChartPage() {
 	const hero = useScopedI18n("ipa-chart.hero-section");
 	const tabs = useScopedI18n("ipa-chart.nav-tabs");
+
+	const [activeTab, setActiveTab] = useQueryState(
+		"tab",
+		parseAsStringEnum<IpaChartTab>([...IPA_CHART_TABS]).withDefault("monophthongs"),
+	);
 
 	return (
 		<div className="flex-1 min-h-0 bg-background">
@@ -21,7 +30,11 @@ export default function IpaChartPage() {
 					</div>
 
 					<div className="p-3 sm:p-6">
-						<Tabs defaultValue="monophthongs" className="gap-5">
+						<Tabs
+							value={activeTab}
+							onValueChange={(value) => setActiveTab(value as IpaChartTab)}
+							className="gap-5"
+						>
 							<ScrollArea>
 								<TabsList className="">
 									<TabsTrigger value="monophthongs">{tabs("monophthongs")}</TabsTrigger>

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { DM_Mono, Inter, Noto_Serif } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import Providers from "./providers";
 import "./globals.css";
 import type { Metadata } from "next";
@@ -57,12 +58,14 @@ export default async function RootLayout({
 		>
 			<body className={`antialiased`}>
 				<I18nProviderClient locale={locale}>
-					<Providers>
-						<div className="h-screen flex flex-col">
-							<Header />
-							{children}
-						</div>
-					</Providers>
+					<NuqsAdapter>
+						<Providers>
+							<div className="h-screen flex flex-col">
+								<Header />
+								{children}
+							</div>
+						</Providers>
+					</NuqsAdapter>
 				</I18nProviderClient>
 				<Analytics />
 				<SpeedInsights />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      nuqs:
+        specifier: ^2.8.0
+        version: 2.8.0(next@15.5.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1190,6 +1193,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1681,6 +1687,27 @@ packages:
       encoding: ^0.1.0
     peerDependenciesMeta:
       encoding:
+        optional: true
+
+  nuqs@2.8.0:
+    resolution: {integrity: sha512-JnVUUNR5hRtt8ZX131KmiGL6IlbyqgXKifL3oYYuDcJ+Kb8fT+WiaMPY7HmfgrECl0FeQBf7H59KfIfbq2DNdw==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
         optional: true
 
   pathe@2.0.3:
@@ -2874,6 +2901,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.50.0':
     optional: true
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3290,6 +3319,13 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  nuqs@2.8.0(next@15.5.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.1.0
+    optionalDependencies:
+      next: 15.5.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   pathe@2.0.3: {}
 


### PR DESCRIPTION
- Install nuqs (v2.8.0) for type-safe search params management
- Add NuqsAdapter to root layout wrapping Providers
- Replace Radix UI defaultValue with controlled tabs via useQueryState
- Tab state now synced to URL query parameter (?tab=monophthongs/diphthongs/consonants)
- Enables shareable URLs and browser back/forward navigation
- Parser defined inline as single-file usage pattern

URL format: /[locale]/ipa-chart?tab=<tab-value>