### PR TITLE
Add copy to clipboard for IPA transcription

### DIFF
--- a/apps/web/src/app/[locale]/(g2p)/_components/transcription-display/index.tsx
+++ b/apps/web/src/app/[locale]/(g2p)/_components/transcription-display/index.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { Check, Copy } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useCurrentTranscription } from "../../_hooks/use-g2p";
+import { extractIpaFromWords } from "../../_lib/extract-ipa";
 import { useDictionaryStore } from "../../_store/dictionary-store";
 import { useG2PStore } from "../../_store/g2p-store";
 import type { TranscribedPhoneme, TranscribedWord } from "../../_types/g2p";
@@ -82,8 +85,10 @@ function WordColumn({ word, onPhonemeClick, selectedSymbol }: WordColumnProps) {
 
 export function TranscriptionDisplay() {
 	const selectPhoneme = useG2PStore((s) => s.selectPhoneme);
+	const { selectedVariants } = useG2PStore();
 	const { data: result } = useCurrentTranscription();
 	const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
+	const [isCopied, setIsCopied] = useState(false);
 	const resultTimestamp = result?.timestamp?.valueOf();
 
 	useEffect(() => {
@@ -99,18 +104,64 @@ export function TranscriptionDisplay() {
 		selectPhoneme(phoneme.phonemeId ?? null);
 	};
 
+	const handleCopyToClipboard = async () => {
+		if (!result) return;
+
+		const ipaText = extractIpaFromWords(result.words, selectedVariants);
+		if (!ipaText) {
+			toast.error("No transcription to copy");
+			return;
+		}
+
+		try {
+			await navigator.clipboard.writeText(ipaText);
+			setIsCopied(true);
+			toast.success("IPA transcription copied to clipboard");
+
+			// Reset the copied state after 2 seconds
+			setTimeout(() => {
+				setIsCopied(false);
+			}, 2000);
+		} catch (error) {
+			toast.error("Failed to copy to clipboard");
+			console.error("Copy to clipboard failed:", error);
+		}
+	};
+
 	if (!result) return <EmptyState />;
 
 	return (
-		<div className="flex flex-wrap items-start justify-center gap-6 md:gap-8 overflow-x-auto bg-muted/20 border border-border/40 p-4 md:p-6">
-			{result.words.map((word, wordIndex) => (
-				<WordColumn
-					key={`${word.word}-${wordIndex}`}
-					word={word}
-					onPhonemeClick={handlePhonemeClick}
-					selectedSymbol={selectedSymbol}
-				/>
-			))}
+		<div className="relative">
+			<div className="flex flex-wrap items-start justify-center gap-6 md:gap-8 overflow-x-auto bg-muted/20 border border-border/40 p-4 md:p-6">
+				{result.words.map((word, wordIndex) => (
+					<WordColumn
+						key={`${word.word}-${wordIndex}`}
+						word={word}
+						onPhonemeClick={handlePhonemeClick}
+						selectedSymbol={selectedSymbol}
+					/>
+				))}
+			</div>
+
+			<button
+				type="button"
+				onClick={handleCopyToClipboard}
+				className={cn(
+					"absolute top-2 right-2 p-2 rounded-md transition-all duration-200",
+					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+					isCopied
+						? "bg-green-500/10 text-green-600 dark:text-green-400"
+						: "bg-background/80 hover:bg-background text-muted-foreground hover:text-foreground border border-border/60 shadow-sm",
+				)}
+				aria-label={isCopied ? "Copied to clipboard" : "Copy IPA transcription to clipboard"}
+				title={isCopied ? "Copied!" : "Copy IPA transcription"}
+			>
+				{isCopied ? (
+					<Check className="h-4 w-4" aria-hidden="true" />
+				) : (
+					<Copy className="h-4 w-4" aria-hidden="true" />
+				)}
+			</button>
 		</div>
 	);
 }

--- a/apps/web/src/app/[locale]/(g2p)/_lib/extract-ipa.ts
+++ b/apps/web/src/app/[locale]/(g2p)/_lib/extract-ipa.ts
@@ -1,0 +1,52 @@
+import type { TranscribedSyllable, TranscribedWord } from "../_types/g2p";
+
+/**
+ * Extracts the complete IPA transcription from a word with the selected variant
+ * Includes stress markers (ˈ primary, ˌ secondary) and syllable separators (·)
+ */
+export function extractIpaFromWord(word: TranscribedWord, selectedVariantIndex: number): string {
+	const variant = word.variants[selectedVariantIndex];
+	if (!variant || word.source === "fallback") {
+		return "";
+	}
+
+	return variant
+		.map((syllable: TranscribedSyllable, syllableIndex: number) => {
+			let syllableText = "";
+
+			// Add stress marker
+			if (syllable.stress === "primary") {
+				syllableText += "ˈ";
+			} else if (syllable.stress === "secondary") {
+				syllableText += "ˌ";
+			}
+
+			// Add phoneme symbols
+			syllableText += syllable.phonemes.map((phoneme) => phoneme.symbol).join("");
+
+			// Add syllable separator (except for last syllable)
+			if (syllableIndex < variant.length - 1) {
+				syllableText += "·";
+			}
+
+			return syllableText;
+		})
+		.join("");
+}
+
+/**
+ * Extracts the complete IPA transcription from all words in a transcription result
+ * Returns space-separated word transcriptions
+ */
+export function extractIpaFromWords(
+	words: TranscribedWord[],
+	selectedVariants: Record<number, number>,
+): string {
+	return words
+		.map((word) => {
+			const variantIndex = selectedVariants[word.wordIndex] ?? 0;
+			return extractIpaFromWord(word, variantIndex);
+		})
+		.filter((ipa) => ipa.length > 0) // Filter out "not found" words
+		.join(" ");
+}


### PR DESCRIPTION
- Add utility function to extract IPA text with stress markers and syllable separators
- Add copy button to transcription display with visual feedback
- Show toast notifications on successful copy or errors
- Button changes to green checkmark when copied, resets after 2 seconds
- Positioned in top-right corner of transcription display