### PR TITLE
Enable definition lookup for unknown words

### DIFF
--- a/apps/web/src/app/[locale]/transcription/_components/transcription-display/index.tsx
+++ b/apps/web/src/app/[locale]/transcription/_components/transcription-display/index.tsx
@@ -34,19 +34,14 @@ function WordColumn({ word, onPhonemeClick, selectedSymbol }: WordColumnProps) {
 				className={cn(
 					"text-lg md:text-xl font-normal mb-3 whitespace-nowrap px-3 py-1 rounded-md transition-colors duration-200",
 					"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-					isUnknown
-						? "text-muted-foreground/50 cursor-default"
-						: "text-muted-foreground hover:bg-muted/50 hover:text-foreground cursor-pointer",
+					"cursor-pointer hover:bg-muted/50 hover:text-foreground",
+					isUnknown ? "text-muted-foreground/50" : "text-muted-foreground",
 				)}
-				onClick={() => !isUnknown && setSelectedWord(word.word)}
-				aria-label={
-					isUnknown
-						? `Word "${word.word}" not found in dictionary`
-						: `Show definition for ${word.word}`
-				}
+				onClick={() => setSelectedWord(word.word)}
+				aria-label={`Show definition for ${word.word}`}
 				title={
 					isUnknown
-						? `"${word.word}" not found in pronunciation dictionary`
+						? `Click to see definition for ${word.word} (pronunciation not in dictionary)`
 						: `Click to see definition for ${word.word}`
 				}
 			>


### PR DESCRIPTION
Allow users to click on words marked as "fallback" (not found in CMU dictionary) to trigger the definition dialog. The word might be real but missing from our pronunciation dictionary, so external dictionary lookup should still be available.

Changes:
- Remove `!isUnknown` check from onClick handler
- Make all words visually clickable with cursor and hover effects
- Update title attribute to indicate dictionary lookup is available
- Maintain visual distinction (lighter text) for unknown words