### PR TITLE
Revert "Add wordfreq credits to credits page"

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -368,17 +368,17 @@
 			"description": "Credits and sources for Phonaria resources, data, and media."
 		},
 		"title": "Credits & Sources",
-		"description": "Phonaria uses open source projects, linguistic research, and freely licensed resources.",
+		"description": "Phonaria builds on the work of open source projects, linguistic research, and public domain resources.",
 		"sections": {
 			"wikimedia": {
 				"title": "Phonetic Audio Samples",
-				"content": "Phonetic audio samples come from the General phonetics gallery on Wikimedia Commons. The recordings were created by Wikimedia contributors and are used under Creative Commons Attribution-ShareAlike and compatible licenses. See individual file pages for authorship and license details.",
+				"content": "Phonetic audio samples used in this app are derived from recordings in the \"General phonetics\" gallery on Wikimedia Commons. The original files were created by various Wikimedia Commons contributors, including Peter Isotalo, Erutuon, Denelson83, and Octane, and are used here under Creative Commons Attribution-ShareAlike and other compatible free licenses. For full authorship and licensing details, please see the individual file pages on Wikimedia Commons.",
 				"link-text": "View General phonetics gallery",
 				"link-url": "https://commons.wikimedia.org/wiki/General_phonetics"
 			},
 			"sagittal": {
 				"title": "Sagittal Illustrations",
-				"content": "Sagittal cross-section diagrams in the articulation panels are adapted from illustrations by Tavin and Nardog on Wikimedia Commons. The original artwork was modified to create consistent variants for each phoneme.",
+				"content": "Sagittal view illustrations used in the articulation panels are adapted from a base illustration by Tavin and Nardog. The original artwork was modified to generate consistent variants for the phonemes in this app.",
 				"link-text": "View original illustration",
 				"link-url": "https://commons.wikimedia.org/wiki/File:Voiceless_dental_fricative_articulation.svg",
 				"license-text": "View CC BY-SA 4.0 license",
@@ -386,33 +386,25 @@
 			},
 			"example-audio": {
 				"title": "Example Word Audio",
-				"content": "Example word recordings in phoneme details are AI-generated. Synthetic audio lets us iterate on the word list without re-recording. When the set stabilizes, we plan to replace these with human recordings."
+				"content": "Example word audio in the phoneme details is currently AI-generated. We use synthetic audio while the word list is still evolving; recording human voices for a changing set would mean frequent replacements and uneven coverage. Modern text-to-speech helps, but it does not replace native-speaker recordings for a pronunciation-first experience. Once the set stabilizes, we will replace these with human recordings and update the credits."
 			},
 			"cmu": {
 				"title": "CMU Pronouncing Dictionary",
-				"content": "Transcription uses the CMU Pronouncing Dictionary from Carnegie Mellon University. The dictionary contains over 134,000 North American English words with phonetic transcriptions and is released under a BSD license.",
-				"link-text": "View CMUdict on GitHub",
+				"content": "The grapheme-to-phoneme transcription feature uses pronunciation data from the CMU Pronouncing Dictionary, a public domain pronunciation dictionary created by Carnegie Mellon University. The dictionary contains over 134,000 North American English words with their phonetic transcriptions.",
+				"link-text": "Learn more about CMU Dict",
 				"link-url": "https://github.com/cmusphinx/cmudict"
-			},
-			"wordfreq": {
-				"title": "wordfreq Word Frequency Data",
-				"content": "Curated word lists for client-side lookup are generated using wordfreq by Robyn Speer. The library combines frequency data from Google Books Ngrams, OpenSubtitles, SUBTLEX, Wikipedia, and other corpora. Data is licensed under CC BY-SA 4.0.",
-				"link-text": "View wordfreq on GitHub",
-				"link-url": "https://github.com/rspeer/wordfreq",
-				"license-text": "View CC BY-SA 4.0 license",
-				"license-url": "https://creativecommons.org/licenses/by-sa/4.0/"
 			},
 			"free-dictionary": {
 				"title": "Free Dictionary API",
-				"content": "Dictionary definitions come from the Free Dictionary API using Wiktionary data. Content is licensed under CC BY-SA 3.0. Audio files cite Wikimedia Commons with per-file licenses.",
+				"content": "Dictionary definitions are provided via the Free Dictionary API (dictionaryapi.dev) using Wiktionary data. Entries carry CC BY-SA 3.0 license metadata, and audio assets cite Wikimedia Commons with per-file licenses.",
 				"link-text": "Visit Free Dictionary API",
 				"link-url": "https://dictionaryapi.dev/",
 				"license-text": "View CC BY-SA 3.0 license",
 				"license-url": "https://creativecommons.org/licenses/by-sa/3.0/"
 			},
 			"phonetic-data": {
-				"title": "Phonetic Data",
-				"content": "Articulatory descriptions, phoneme features, and IPA classifications draw from standard phonetic references and linguistics research."
+				"title": "Phonetic Data & Resources",
+				"content": "Articulatory descriptions, phoneme features, and IPA classifications are compiled from established phonetic resources, linguistic research, and educational materials in the public domain."
 			}
 		}
 	},

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -368,17 +368,17 @@
 			"description": "Créditos y fuentes de los recursos, datos y materiales de Phonaria."
 		},
 		"title": "Créditos y fuentes",
-		"description": "Phonaria utiliza proyectos de código abierto, investigación lingüística y recursos con licencias libres.",
+		"description": "Phonaria se basa en el trabajo de proyectos de código abierto, investigación lingüística y recursos de dominio público.",
 		"sections": {
 			"wikimedia": {
 				"title": "Muestras de audio fonético",
-				"content": "Las muestras de audio fonético provienen de la galería General phonetics en Wikimedia Commons. Las grabaciones fueron creadas por colaboradores de Wikimedia y se usan bajo licencias Creative Commons Atribución-CompartirIgual y compatibles. Consulta las páginas de cada archivo para ver autoría y licencia.",
-				"link-text": "Ver galería General phonetics",
+				"content": "Las muestras de audio fonético usadas en esta aplicación provienen de grabaciones en la galería \"General phonetics\" de Wikimedia Commons. Los archivos originales fueron creados por varios colaboradores de Wikimedia Commons, incluidos Peter Isotalo, Erutuon, Denelson83 y Octane, y se usan aquí bajo licencias Creative Commons Atribución-CompartirIgual y otras licencias libres compatibles. Para detalles completos de autoría y licencias, consulta las páginas individuales de los archivos en Wikimedia Commons.",
+				"link-text": "Ver la galería «General phonetics»",
 				"link-url": "https://commons.wikimedia.org/wiki/General_phonetics"
 			},
 			"sagittal": {
 				"title": "Ilustraciones sagitales",
-				"content": "Los diagramas de corte sagital en los paneles de articulación se adaptan de ilustraciones de Tavin y Nardog en Wikimedia Commons. El trabajo original se modificó para crear variantes consistentes para cada fonema.",
+				"content": "Las ilustraciones de vista sagital usadas en los paneles de articulación se adaptan a partir de una ilustración base de Tavin y Nardog. El trabajo original se modificó para generar variantes consistentes para los fonemas de esta aplicación.",
 				"link-text": "Ver ilustración original",
 				"link-url": "https://commons.wikimedia.org/wiki/File:Voiceless_dental_fricative_articulation.svg",
 				"license-text": "Ver licencia CC BY-SA 4.0",
@@ -386,33 +386,25 @@
 			},
 			"example-audio": {
 				"title": "Audio de palabras de ejemplo",
-				"content": "Las grabaciones de palabras de ejemplo en los detalles de fonemas son generadas por IA. El audio sintético permite iterar la lista de palabras sin regrabar. Cuando el conjunto se estabilice, planeamos reemplazarlas por grabaciones humanas."
+				"content": "El audio de palabras de ejemplo en los detalles de los fonemas es actualmente generado por IA. Usamos audio sintético mientras la lista de palabras sigue cambiando; grabar voces humanas para un conjunto inestable implicaría reemplazos frecuentes y una cobertura desigual. La síntesis de voz actual ayuda, pero no sustituye las grabaciones de hablantes nativos en una experiencia centrada en la pronunciación. Cuando el conjunto se estabilice, lo reemplazaremos por grabaciones humanas y actualizaremos los créditos."
 			},
 			"cmu": {
-				"title": "Diccionario de pronunciación CMU",
-				"content": "La transcripción usa el CMU Pronouncing Dictionary de Carnegie Mellon University. El diccionario contiene más de 134.000 palabras del inglés norteamericano con transcripciones fonéticas y se distribuye bajo licencia BSD.",
-				"link-text": "Ver CMUdict en GitHub",
+				"title": "Diccionario de pronunciación de CMU",
+				"content": "La función de transcripción de grafemas a fonemas usa datos de pronunciación del Diccionario de pronunciación de CMU, un diccionario de pronunciación de dominio público creado por la Universidad Carnegie Mellon. El diccionario contiene más de 134.000 palabras del inglés norteamericano con sus transcripciones fonéticas.",
+				"link-text": "Más información sobre CMU Dict",
 				"link-url": "https://github.com/cmusphinx/cmudict"
-			},
-			"wordfreq": {
-				"title": "Datos de frecuencia wordfreq",
-				"content": "Las listas curadas de palabras para búsqueda local se generan con wordfreq de Robyn Speer. La biblioteca combina datos de frecuencia de Google Books Ngrams, OpenSubtitles, SUBTLEX, Wikipedia y otros corpus. Los datos están bajo licencia CC BY-SA 4.0.",
-				"link-text": "Ver wordfreq en GitHub",
-				"link-url": "https://github.com/rspeer/wordfreq",
-				"license-text": "Ver licencia CC BY-SA 4.0",
-				"license-url": "https://creativecommons.org/licenses/by-sa/4.0/"
 			},
 			"free-dictionary": {
 				"title": "API de Free Dictionary",
-				"content": "Las definiciones provienen de la API de Free Dictionary usando datos de Wiktionary. El contenido está bajo licencia CC BY-SA 3.0. Los archivos de audio citan Wikimedia Commons con licencias por archivo.",
-				"link-text": "Visitar API de Free Dictionary",
+				"content": "Las definiciones del diccionario se proporcionan mediante la API de Free Dictionary (dictionaryapi.dev) usando datos de Wiktionary. Las entradas incluyen metadatos de licencia CC BY-SA 3.0 y el audio de pronunciación se obtiene de Wikimedia Commons, con licencias específicas por archivo.",
+				"link-text": "Visitar la API de Free Dictionary",
 				"link-url": "https://dictionaryapi.dev/",
 				"license-text": "Ver licencia CC BY-SA 3.0",
 				"license-url": "https://creativecommons.org/licenses/by-sa/3.0/"
 			},
 			"phonetic-data": {
-				"title": "Datos fonéticos",
-				"content": "Las descripciones articulatorias, rasgos fonémicos y clasificaciones IPA provienen de referencias fonéticas estándar e investigación lingüística."
+				"title": "Datos y recursos fonéticos",
+				"content": "Las descripciones articulatorias, los rasgos fonémicos y las clasificaciones IPA se compilan a partir de recursos fonéticos establecidos, investigación lingüística y materiales educativos de dominio público."
 			}
 		}
 	},

--- a/apps/web/src/app/[locale]/credits/page.tsx
+++ b/apps/web/src/app/[locale]/credits/page.tsx
@@ -1,5 +1,3 @@
-import { Badge } from "@phonaria/ui/components/badge";
-import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import { type Locale, useTranslations } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
@@ -29,58 +27,6 @@ export async function generateMetadata({
 	};
 }
 
-type CreditCardProps = {
-	title: string;
-	content: string;
-	link?: {
-		text: string;
-		url: string;
-	};
-	license?: {
-		text: string;
-		url: string;
-	};
-};
-
-function CreditCard({ title, content, link, license }: CreditCardProps) {
-	return (
-		<div className="flex flex-col rounded-xl bg-card text-card-foreground ring-1 ring-foreground/10 overflow-hidden h-full">
-			<div className="p-4">
-				<h2 className="text-base font-semibold tracking-tight">{title}</h2>
-				<p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">{content}</p>
-			</div>
-
-			{(link || license) && (
-				<div className="mt-auto border-t border-border/50 bg-muted/30 px-4 py-3 flex flex-wrap items-center gap-x-4 gap-y-2">
-					{link && (
-						<a
-							href={link.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline underline-offset-2"
-						>
-							{link.text}
-							<ExternalLink className="size-3.5" />
-						</a>
-					)}
-					{license && (
-						<a
-							href={license.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-						>
-							<Badge variant="outline" className="font-normal">
-								{license.text}
-							</Badge>
-						</a>
-					)}
-				</div>
-			)}
-		</div>
-	);
-}
-
 export default function CreditsPage({ params }: PageProps<"/[locale]/credits">) {
 	const { locale } = use(params);
 
@@ -88,60 +34,112 @@ export default function CreditsPage({ params }: PageProps<"/[locale]/credits">) 
 
 	const t = useTranslations("credits-page");
 
-	const credits = [
-		{
-			key: "wikimedia",
-			link: { text: t("sections.wikimedia.link-text"), url: t("sections.wikimedia.link-url") },
-		},
-		{
-			key: "sagittal",
-			link: { text: t("sections.sagittal.link-text"), url: t("sections.sagittal.link-url") },
-			license: { text: "CC BY-SA 4.0", url: t("sections.sagittal.license-url") },
-		},
-		{
-			key: "cmu",
-			link: { text: t("sections.cmu.link-text"), url: t("sections.cmu.link-url") },
-			license: { text: "BSD", url: "https://github.com/cmusphinx/cmudict/blob/master/LICENSE" },
-		},
-		{
-			key: "wordfreq",
-			link: { text: t("sections.wordfreq.link-text"), url: t("sections.wordfreq.link-url") },
-			license: { text: "CC BY-SA 4.0", url: t("sections.wordfreq.license-url") },
-		},
-		{
-			key: "free-dictionary",
-			link: {
-				text: t("sections.free-dictionary.link-text"),
-				url: t("sections.free-dictionary.link-url"),
-			},
-			license: { text: "CC BY-SA 3.0", url: t("sections.free-dictionary.license-url") },
-		},
-		{
-			key: "example-audio",
-		},
-		{
-			key: "phonetic-data",
-		},
-	] as const;
-
 	return (
-		<div className="flex flex-1 flex-col bg-background">
-			<div className="container mx-auto p-4 sm:p-6 max-w-6xl space-y-6">
-				<div className="flex flex-col gap-1">
-					<h1 className="text-xl sm:text-2xl font-bold tracking-tight">{t("title")}</h1>
-					<p className="text-sm text-muted-foreground">{t("description")}</p>
-				</div>
+		<div className="flex flex-1 flex-col bg-background overflow-y-auto">
+			<div className="container mx-auto p-4 py-6 sm:p-6 lg:p-8 max-w-4xl bg-background-soft">
+				<h1 className="text-3xl font-bold mb-2">{t("title")}</h1>
+				<p className="text-muted-foreground mb-8">{t("description")}</p>
 
-				<div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-					{credits.map((credit) => (
-						<CreditCard
-							key={credit.key}
-							title={t(`sections.${credit.key}.title`)}
-							content={t(`sections.${credit.key}.content`)}
-							link={"link" in credit ? credit.link : undefined}
-							license={"license" in credit ? credit.license : undefined}
-						/>
-					))}
+				<div className="space-y-8">
+					{/* Wikimedia Commons Audio Samples */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.wikimedia.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.wikimedia.content")}
+						</p>
+						<a
+							href={t("sections.wikimedia.link-url")}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-block text-sm text-primary hover:underline"
+						>
+							{t("sections.wikimedia.link-text")} →
+						</a>
+					</section>
+
+					{/* Sagittal Illustrations */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.sagittal.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.sagittal.content")}
+						</p>
+						<div className="flex flex-col sm:flex-row sm:items-center gap-2">
+							<a
+								href={t("sections.sagittal.link-url")}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-block text-sm text-primary hover:underline"
+							>
+								{t("sections.sagittal.link-text")} →
+							</a>
+							<a
+								href={t("sections.sagittal.license-url")}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-block text-xs text-muted-foreground hover:underline"
+							>
+								{t("sections.sagittal.license-text")}
+							</a>
+						</div>
+					</section>
+
+					{/* CMU Pronouncing Dictionary */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.cmu.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.cmu.content")}
+						</p>
+						<a
+							href={t("sections.cmu.link-url")}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-block text-sm text-primary hover:underline"
+						>
+							{t("sections.cmu.link-text")} →
+						</a>
+					</section>
+
+					{/* Free Dictionary API */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.free-dictionary.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.free-dictionary.content")}
+						</p>
+						<div className="flex flex-col sm:flex-row sm:items-center gap-2">
+							<a
+								href={t("sections.free-dictionary.link-url")}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-block text-sm text-primary hover:underline"
+							>
+								{t("sections.free-dictionary.link-text")} →
+							</a>
+							<a
+								href={t("sections.free-dictionary.license-url")}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-block text-xs text-muted-foreground hover:underline"
+							>
+								{t("sections.free-dictionary.license-text")}
+							</a>
+						</div>
+					</section>
+
+					{/* Phonetic Data Sources */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.phonetic-data.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.phonetic-data.content")}
+						</p>
+					</section>
+
+					{/* Example Word Audio */}
+					<section className="space-y-3">
+						<h2 className="text-xl font-semibold">{t("sections.example-audio.title")}</h2>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							{t("sections.example-audio.content")}
+						</p>
+					</section>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Reverts rigomart/phonaria#73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced credits page with more detailed attribution and licensing information for all resources
  * Clarified that example audio is currently AI-generated with plans to replace with human recordings
  * Removed word frequency section from credits
  * Expanded source attribution and contributor details for Wikimedia, CMU Dictionary, and Free Dictionary
  * Updated messaging in both English and Spanish localizations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->