### PR TITLE
chore(ci): add bun setup to deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 


### PR DESCRIPTION
## Summary
- Adds `oven-sh/setup-bun@v2` to both `deploy.yml` and `release.yml` deploy jobs
- Fixes `spawn bun ENOENT` error when Vercel CLI detects `bun.lock` and tries to use bun

## Test plan
- [ ] Trigger manual deploy and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to improve build infrastructure setup and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->