### PR TITLE
fix(seo): add noindex to credits page

### DIFF
--- a/apps/web/src/app/[locale]/credits/page.tsx
+++ b/apps/web/src/app/[locale]/credits/page.tsx
@@ -26,6 +26,10 @@ export async function generateMetadata({
 			canonical: getLocalePath(locale, "/credits"),
 			languages: getLanguageAlternates("/credits"),
 		},
+		robots: {
+			index: false,
+			follow: true,
+		},
 	};
 }
 


### PR DESCRIPTION
## Summary
- Add `robots: { index: false, follow: true }` metadata to the credits page
- Prevents search engines from indexing the credits page while allowing link following
- Users searching for Phonaria will land on feature pages instead of attribution content

## Test plan
- [x] Verified `<meta name="robots" content="noindex, follow">` appears in page source
- [x] Ran `bun lint` - passed
- [x] Ran `bun check-types` - passed

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine indexing settings for the credits page to prevent indexing by search engines while allowing link following.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->