### PR TITLE
fix(ui): increase IPA symbol prominence in overview section

### DIFF
--- a/apps/web/src/app/[locale]/(overview)/_components/ipa-intro-section.tsx
+++ b/apps/web/src/app/[locale]/(overview)/_components/ipa-intro-section.tsx
@@ -124,15 +124,15 @@ function WordCard({
 			</span>
 
 			{/* IPA transcription with individual phoneme buttons */}
-			<div className="flex items-center gap-0.5 text-sm">
+			<div className="flex items-center gap-0.5 text-base">
 				<span className="text-muted-foreground">/</span>
 				<ButtonGroup>
 					{example.phonemes.map((phoneme, index) => (
 						<Button
 							key={`${example.word}-${phoneme.symbol}-${index}`}
-							size="xs"
+							size="sm"
 							variant={phoneme.isHighlighted ? "default" : "outline"}
-							className="min-w-6 font-serif"
+							className="min-w-7 font-serif text-base"
 							onClick={() => onPhonemeClick(phoneme.id)}
 						>
 							{phoneme.symbol}
@@ -161,7 +161,7 @@ export function IpaIntroSection() {
 								<code className="bg-muted px-1.5 py-0.5 rounded font-semibold">{chunks}</code>
 							),
 							highlight: (chunks) => (
-								<span className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-xs font-serif bg-primary text-primary-foreground">
+								<span className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-sm font-serif bg-primary text-primary-foreground">
 									{chunks}
 								</span>
 							),


### PR DESCRIPTION
## Summary
Fixes the visual hierarchy in the IPA Intro section of the overview page by increasing IPA symbol sizes to make them stand out as the primary content.

## Problem
IPA symbols in the overview page were displayed smaller than the surrounding text, despite being the main highlight of the section.

## Changes
- Change IPA container from `text-sm` to `text-base`
- Upgrade phoneme buttons from `size="xs"` to `size="sm"` with `text-base`
- Increase inline IPA highlight from `text-xs` to `text-sm`

## Verification
- [x] `bun lint` passes
- [x] `bun check-types` passes
- Visual comparison confirms IPA symbols are now more prominent

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual presentation of IPA phoneme controls with improved typography sizing and spacing
  * Updated phoneme button dimensions for better usability
  * Refined highlight styling in descriptions for improved readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->