### PR TITLE
feat(test): add Playwright E2E testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 
 # Testing
 /coverage/
+test-results/
+playwright-report/
+playwright/.cache/
 
 # Environment variables
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ The web app uses Next.js App Router with internationalization:
 - `bun lint`: Run Biome check with auto-fixing (`--write`); commits should land clean.
 - `bun check-types`: Run `tsc --noEmit` across packages to maintain strict type safety.
 - `bun test`: Execute Vitest test suites via Turborepo; use `bun --filter @phonaria/app test` for targeted runs.
+- `bun e2e`: Run Playwright E2E tests against the web app (requires `SKIP_RATE_LIMIT=true` and `DATABASE_URL`).
+- `bun --cwd apps/web e2e:ui`: Open Playwright UI for interactive test debugging.
+- `bun --cwd apps/web e2e:install`: Install Playwright browsers (Chromium).
 - `bun --cwd packages/helper-scripts generate`: Regenerate ElevenLabs pronunciation audio (requires `ELEVENLABS_API_KEY` in `packages/helper-scripts/.env`).
 - `bun --cwd packages/helper-scripts cmudict-to-json`: Convert CMUDict plaintext to JSON format consumed by the app (configure `CMUDICT_SRC_URL` or `CMUDICT_JSON_PATH`).
 - `bun --cwd packages/helper-scripts cmudict-stats`: Build CMUDict coverage statistics used by the insights page.
@@ -99,9 +102,11 @@ React 19 + Next.js 15 App Router, Tailwind CSS v4 + shadcn/ui (Radix), Zustand +
 - AVOID using emojis in the codebase and documentation.
 
 ## Testing Guidelines
-- Vitest drives `apps/web` tests; co-locate specs using `.test.ts` suffix (e.g. `apps/web/src/data/phoneme-details.test.ts`).
+- Vitest drives `apps/web` unit tests; co-locate specs using `.test.ts` suffix (e.g. `apps/web/src/data/phoneme-details.test.ts`).
 - Favor fast unit coverage on data transformations, API helpers, and utilities; integration tests should mock network boundaries.
 - Test phonetics-data packages separately to ensure metadata integrity.
+- E2E tests live in `apps/web/e2e/` using Playwright; they test main user flows (transcription, find-by-sound, navigation).
+- E2E tests run automatically on push to main via `.github/workflows/e2e.yml`.
 - Before pushing, run `bun test`, `bun lint`, and `bun check-types` to catch issues early.
 
 ## Commit & Pull Request Guidelines

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -32,7 +32,7 @@ This package hosts the primary Phonaria experience: a Next.js App Router project
  - **Database** – Drizzle ORM with Neon PostgreSQL for persisted data
  - **Rate Limiting** – Upstash Redis for API endpoint protection
 - **Analytics** – Vercel Analytics and Speed Insights
-- **Testing** – Vitest with utility-first unit coverage for API services, hooks, and data transformations
+- **Testing** – Vitest for unit tests, Playwright for E2E tests covering main user flows
 - **Linting & Formatting** – Biome (tab indentation, 100-char line width, auto-import organization)
 
 ## Running locally
@@ -49,7 +49,10 @@ The root `bun dev` will also start this project if you prefer Turborepo orchestr
  ```bash
  bun --cwd apps/web lint            # biome check --write
  bun --cwd apps/web check-types     # tsc --noEmit
- bun --cwd apps/web test            # vitest run
+ bun --cwd apps/web test            # vitest run (unit tests)
+ bun --cwd apps/web e2e             # playwright test (E2E tests)
+ bun --cwd apps/web e2e:ui          # playwright test --ui (interactive)
+ bun --cwd apps/web e2e:install     # install playwright browsers
  bun --cwd apps/web build           # next build --turbopack
  bun --cwd apps/web start           # next start (after build)
  bun --cwd apps/web db:push         # drizzle-kit push (database schema)
@@ -64,6 +67,7 @@ The tree below is illustrative; prefixed folders (`_components`, `_hooks`, `_lib
 
 ```
 apps/web
+├── e2e/                  # Playwright E2E tests
 ├── messages/             # next-intl message catalogs (e.g., en.json, es.json)
 ├── public/               # Static assets (SVG icons, optional audio)
 ├── src/
@@ -117,6 +121,7 @@ apps/web
 │   │   ├── utils.ts       # General helper functions
 │   │   └── vowel-chart-geometry.ts
 ├── next.config.ts         # Next.js configuration (CSP headers, etc.)
+├── playwright.config.ts   # Playwright E2E test configuration
 ├── tsconfig.json          # TypeScript configuration
 └── vitest.config.ts       # Vitest test runner configuration
 ```
@@ -229,7 +234,14 @@ Create a `.env.local` file in `apps/web` with the following variables:
 
 ## Testing guidance
 
-Unit tests live alongside the code they cover using `.test.ts` suffix (e.g., `src/data/phoneme-details.test.ts`). Run `bun --cwd apps/web test` locally or rely on the root `bun test` command for workspace-wide coverage.
+**Unit tests** live alongside the code they cover using `.test.ts` suffix (e.g., `src/data/phoneme-details.test.ts`). Run `bun --cwd apps/web test` locally or rely on the root `bun test` command for workspace-wide coverage.
+
+**E2E tests** live in `e2e/` and use Playwright to test main user flows:
+- `transcription.spec.ts` – Transcribe text, view phoneme details, copy button
+- `find-by-sound.spec.ts` – Search by phoneme patterns, build sequences
+- `navigation.spec.ts` – Navigate between pages, switch locale
+
+Run E2E tests locally with `SKIP_RATE_LIMIT=true bun --cwd apps/web e2e`. E2E tests run automatically on push to main via GitHub Actions.
 
  ## Security
 

--- a/apps/web/e2e/find-by-sound.spec.ts
+++ b/apps/web/e2e/find-by-sound.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Find by Sound Flow", () => {
+	test("user can search words by phoneme pattern", async ({ page }) => {
+		await page.goto("/en/find-by-sound");
+
+		// User clicks a phoneme on the keyboard (e.g., /k/)
+		const kButton = page.locator("button").filter({ hasText: /^k$/ }).first();
+		await kButton.click();
+
+		// User sees search results
+		await expect(page.getByText(/results|found|words/i).first()).toBeVisible({ timeout: 10_000 });
+
+		// Results should include words starting with /k/
+		await expect(page.getByText(/cat|can|car|come|keep/i).first()).toBeVisible();
+	});
+
+	test("user can build multi-phoneme sequences", async ({ page }) => {
+		await page.goto("/en/find-by-sound");
+
+		// User builds /kæ/ sequence
+		await page.locator("button").filter({ hasText: /^k$/ }).first().click();
+		await page.waitForTimeout(500);
+
+		await page.locator("button").filter({ hasText: /^æ$/ }).first().click();
+
+		// Results should narrow to words with /kæ/ pattern
+		await expect(page.getByText(/results|found/i).first()).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("user can clear phoneme selection and start over", async ({ page }) => {
+		await page.goto("/en/find-by-sound");
+
+		// Select a phoneme
+		await page.locator("button").filter({ hasText: /^p$/ }).first().click();
+		await page.waitForTimeout(500);
+
+		// Clear the selection
+		const clearButton = page.getByRole("button", { name: /clear/i });
+		await clearButton.click();
+
+		// Empty state message should reappear
+		await expect(page.getByText(/select|click|choose/i).first()).toBeVisible();
+	});
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Navigation Flow", () => {
+	test("user can navigate between main pages", async ({ page }) => {
+		// Start at transcription page
+		await page.goto("/en/transcription");
+		await expect(page.getByLabel("Text to transcribe")).toBeVisible();
+
+		// Navigate to IPA Chart via header link
+		await page.getByRole("link", { name: /ipa/i }).first().click();
+		await expect(page).toHaveURL("/en/ipa-chart");
+
+		// Navigate to Insights
+		await page
+			.getByRole("link", { name: /insights/i })
+			.first()
+			.click();
+		await expect(page).toHaveURL("/en/insights");
+
+		// Navigate back to landing
+		await page.getByText("Phonaria").first().click();
+		await expect(page).toHaveURL("/en");
+	});
+
+	test("user can switch locale", async ({ page }) => {
+		await page.goto("/en/transcription");
+
+		// Click the language switcher (aria-label="Language")
+		await page.getByRole("button", { name: "Language" }).click();
+
+		// Select Spanish
+		await page.getByRole("menuitem", { name: /spanish/i }).click();
+
+		// URL should change to Spanish locale
+		await expect(page).toHaveURL(/\/es\/transcription/);
+
+		// Page content should be in Spanish
+		await expect(page.getByLabel(/texto.*transcribir/i)).toBeVisible();
+	});
+});

--- a/apps/web/e2e/transcription.spec.ts
+++ b/apps/web/e2e/transcription.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Transcription Flow", () => {
+	test("user can transcribe text and see IPA output", async ({ page }) => {
+		await page.goto("/en/transcription");
+
+		// User types text
+		const input = page.getByLabel("Text to transcribe");
+		await input.fill("hello world");
+
+		// User submits
+		await page.locator("button[type='submit']").click();
+
+		// User sees both words transcribed
+		await expect(page.getByText("hello").first()).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText("world").first()).toBeVisible();
+
+		// IPA phoneme buttons are present (clickable phoneme symbols)
+		const phonemeButtons = page.locator("button").filter({ hasText: /^[hɛloʊwɝd]$/ });
+		await expect(phonemeButtons.first()).toBeVisible();
+	});
+
+	test("user can click a phoneme to see details", async ({ page }) => {
+		await page.goto("/en/transcription");
+
+		// Transcribe a simple word
+		await page.getByLabel("Text to transcribe").fill("cat");
+		await page.locator("button[type='submit']").click();
+
+		// Wait for transcription
+		await expect(page.getByText("cat").first()).toBeVisible({ timeout: 15_000 });
+
+		// Click a phoneme button
+		const phonemeButton = page
+			.locator("button")
+			.filter({ hasText: /^[kæt]$/ })
+			.first();
+		await phonemeButton.click();
+
+		// User sees phoneme details (look for "Pronunciation" heading or articulation content)
+		await expect(page.getByText(/pronunciation|how this sound/i).first()).toBeVisible({
+			timeout: 5_000,
+		});
+	});
+
+	test("copy button is available after transcription", async ({ page }) => {
+		await page.goto("/en/transcription");
+
+		await page.getByLabel("Text to transcribe").fill("test");
+		await page.locator("button[type='submit']").click();
+
+		await expect(page.getByText("test").first()).toBeVisible({ timeout: 15_000 });
+
+		// Copy button should be visible and clickable
+		const copyButton = page.getByRole("button", { name: /copy/i });
+		await expect(copyButton).toBeVisible();
+		await expect(copyButton).toBeEnabled();
+	});
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,9 @@
 		"lint": "biome check --write",
 		"check-types": "tsc --noEmit",
 		"test": "vitest run",
+		"e2e": "playwright test",
+		"e2e:ui": "playwright test --ui",
+		"e2e:install": "playwright install chromium --with-deps",
 		"db:push": "drizzle-kit push",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
@@ -41,6 +44,7 @@
 	},
 	"devDependencies": {
 		"@next/env": "^16.1.1",
+		"@playwright/test": "^1.58.0",
 		"@tailwindcss/postcss": "^4.1.12",
 		"@types/node": "^20",
 		"@types/pg": "^8.16.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.PORT ?? "3000";
+const BASE_URL = `http://localhost:${PORT}`;
+const IS_CI = !!process.env.CI;
+
+export default defineConfig({
+	testDir: "./e2e",
+	fullyParallel: true,
+	forbidOnly: IS_CI,
+	retries: IS_CI ? 2 : 0,
+	workers: IS_CI ? 1 : undefined,
+	reporter: IS_CI ? "github" : "html",
+	timeout: 30_000,
+	expect: { timeout: 10_000 },
+
+	use: {
+		baseURL: BASE_URL,
+		trace: "on-first-retry",
+		screenshot: "only-on-failure",
+	},
+
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+
+	webServer: {
+		command: IS_CI ? "bun run start" : "bun run dev",
+		url: BASE_URL,
+		reuseExistingServer: !IS_CI,
+		timeout: 120_000,
+		env: {
+			SKIP_RATE_LIMIT: "true",
+		},
+	},
+});

--- a/apps/web/src/lib/safe-action.ts
+++ b/apps/web/src/lib/safe-action.ts
@@ -25,13 +25,20 @@ export class ActionError extends Error {
 /**
  * Rate limiter instance using Upstash Redis.
  * 20 requests per 10 seconds sliding window.
+ * Lazily initialized to avoid connection errors when Redis env vars are absent (e.g. E2E tests).
  */
-const ratelimit = new Ratelimit({
-	redis: Redis.fromEnv(),
-	limiter: Ratelimit.slidingWindow(20, "10 s"),
-	analytics: true,
-	timeout: 10000,
-});
+let _ratelimit: Ratelimit | null = null;
+function getRatelimit(): Ratelimit {
+	if (!_ratelimit) {
+		_ratelimit = new Ratelimit({
+			redis: Redis.fromEnv(),
+			limiter: Ratelimit.slidingWindow(20, "10 s"),
+			analytics: true,
+			timeout: 10000,
+		});
+	}
+	return _ratelimit;
+}
 
 /**
  * Get client IP address from request headers.
@@ -89,8 +96,12 @@ export const actionClient = createSafeActionClient({
  * Use this for public-facing actions.
  */
 export const rateLimitedAction = actionClient.use(async ({ next }) => {
+	if (process.env.SKIP_RATE_LIMIT === "true" && process.env.NODE_ENV !== "production") {
+		return next();
+	}
+
 	const ip = await getClientIP();
-	const { success, pending, reset } = await ratelimit.limit(ip);
+	const { success, pending, reset } = await getRatelimit().limit(ip);
 
 	if (!success) {
 		await pending;

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       },
       "devDependencies": {
         "@next/env": "^16.1.1",
+        "@playwright/test": "^1.58.0",
         "@tailwindcss/postcss": "^4.1.12",
         "@types/node": "^20",
         "@types/pg": "^8.16.0",
@@ -122,7 +123,7 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.985.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.7", "@aws-sdk/credential-provider-node": "^3.972.6", "@aws-sdk/middleware-bucket-endpoint": "^3.972.3", "@aws-sdk/middleware-expect-continue": "^3.972.3", "@aws-sdk/middleware-flexible-checksums": "^3.972.5", "@aws-sdk/middleware-host-header": "^3.972.3", "@aws-sdk/middleware-location-constraint": "^3.972.3", "@aws-sdk/middleware-logger": "^3.972.3", "@aws-sdk/middleware-recursion-detection": "^3.972.3", "@aws-sdk/middleware-sdk-s3": "^3.972.7", "@aws-sdk/middleware-ssec": "^3.972.3", "@aws-sdk/middleware-user-agent": "^3.972.7", "@aws-sdk/region-config-resolver": "^3.972.3", "@aws-sdk/signature-v4-multi-region": "3.985.0", "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-endpoints": "3.985.0", "@aws-sdk/util-user-agent-browser": "^3.972.3", "@aws-sdk/util-user-agent-node": "^3.972.5", "@smithy/config-resolver": "^4.4.6", "@smithy/core": "^3.22.1", "@smithy/eventstream-serde-browser": "^4.2.8", "@smithy/eventstream-serde-config-resolver": "^4.3.8", "@smithy/eventstream-serde-node": "^4.2.8", "@smithy/fetch-http-handler": "^5.3.9", "@smithy/hash-blob-browser": "^4.2.9", "@smithy/hash-node": "^4.2.8", "@smithy/hash-stream-node": "^4.2.8", "@smithy/invalid-dependency": "^4.2.8", "@smithy/md5-js": "^4.2.8", "@smithy/middleware-content-length": "^4.2.8", "@smithy/middleware-endpoint": "^4.4.13", "@smithy/middleware-retry": "^4.4.30", "@smithy/middleware-serde": "^4.2.9", "@smithy/middleware-stack": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/node-http-handler": "^4.4.9", "@smithy/protocol-http": "^5.3.8", "@smithy/smithy-client": "^4.11.2", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.29", "@smithy/util-defaults-mode-node": "^4.2.32", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/util-stream": "^4.5.11", "@smithy/util-utf8": "^4.2.0", "@smithy/util-waiter": "^4.2.8", "tslib": "^2.6.2" } }, "sha512-S9TqjzzZEEIKBnC7yFpvqM7CG9ALpY5qhQ5BnDBJtdG20NoGpjKLGUUfD2wmZItuhbrcM4Z8c6m6Fg0XYIOVvw=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.986.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.7", "@aws-sdk/credential-provider-node": "^3.972.6", "@aws-sdk/middleware-bucket-endpoint": "^3.972.3", "@aws-sdk/middleware-expect-continue": "^3.972.3", "@aws-sdk/middleware-flexible-checksums": "^3.972.5", "@aws-sdk/middleware-host-header": "^3.972.3", "@aws-sdk/middleware-location-constraint": "^3.972.3", "@aws-sdk/middleware-logger": "^3.972.3", "@aws-sdk/middleware-recursion-detection": "^3.972.3", "@aws-sdk/middleware-sdk-s3": "^3.972.7", "@aws-sdk/middleware-ssec": "^3.972.3", "@aws-sdk/middleware-user-agent": "^3.972.7", "@aws-sdk/region-config-resolver": "^3.972.3", "@aws-sdk/signature-v4-multi-region": "3.986.0", "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-endpoints": "3.986.0", "@aws-sdk/util-user-agent-browser": "^3.972.3", "@aws-sdk/util-user-agent-node": "^3.972.5", "@smithy/config-resolver": "^4.4.6", "@smithy/core": "^3.22.1", "@smithy/eventstream-serde-browser": "^4.2.8", "@smithy/eventstream-serde-config-resolver": "^4.3.8", "@smithy/eventstream-serde-node": "^4.2.8", "@smithy/fetch-http-handler": "^5.3.9", "@smithy/hash-blob-browser": "^4.2.9", "@smithy/hash-node": "^4.2.8", "@smithy/hash-stream-node": "^4.2.8", "@smithy/invalid-dependency": "^4.2.8", "@smithy/md5-js": "^4.2.8", "@smithy/middleware-content-length": "^4.2.8", "@smithy/middleware-endpoint": "^4.4.13", "@smithy/middleware-retry": "^4.4.30", "@smithy/middleware-serde": "^4.2.9", "@smithy/middleware-stack": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/node-http-handler": "^4.4.9", "@smithy/protocol-http": "^5.3.8", "@smithy/smithy-client": "^4.11.2", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.29", "@smithy/util-defaults-mode-node": "^4.2.32", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/util-stream": "^4.5.11", "@smithy/util-utf8": "^4.2.0", "@smithy/util-waiter": "^4.2.8", "tslib": "^2.6.2" } }, "sha512-IcDJ8shVVvbxgMe8+dLWcv6uhSwmX65PHTVGX81BhWAElPnp3CL8w/5uzOPRo4n4/bqIk9eskGVEIicw2o+SrA=="],
 
     "@aws-sdk/client-sso": ["@aws-sdk/client-sso@3.985.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.7", "@aws-sdk/middleware-host-header": "^3.972.3", "@aws-sdk/middleware-logger": "^3.972.3", "@aws-sdk/middleware-recursion-detection": "^3.972.3", "@aws-sdk/middleware-user-agent": "^3.972.7", "@aws-sdk/region-config-resolver": "^3.972.3", "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-endpoints": "3.985.0", "@aws-sdk/util-user-agent-browser": "^3.972.3", "@aws-sdk/util-user-agent-node": "^3.972.5", "@smithy/config-resolver": "^4.4.6", "@smithy/core": "^3.22.1", "@smithy/fetch-http-handler": "^5.3.9", "@smithy/hash-node": "^4.2.8", "@smithy/invalid-dependency": "^4.2.8", "@smithy/middleware-content-length": "^4.2.8", "@smithy/middleware-endpoint": "^4.4.13", "@smithy/middleware-retry": "^4.4.30", "@smithy/middleware-serde": "^4.2.9", "@smithy/middleware-stack": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/node-http-handler": "^4.4.9", "@smithy/protocol-http": "^5.3.8", "@smithy/smithy-client": "^4.11.2", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.29", "@smithy/util-defaults-mode-node": "^4.2.32", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-81J8iE8MuXhdbMfIz4sWFj64Pe41bFi/uqqmqOC5SlGv+kwoyLsyKS/rH2tW2t5buih4vTUxskRjxlqikTD4oQ=="],
 
@@ -170,7 +171,7 @@
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.3", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/config-resolver": "^4.4.6", "@smithy/node-config-provider": "^4.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow=="],
 
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.985.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.7", "@aws-sdk/types": "^3.973.1", "@smithy/protocol-http": "^5.3.8", "@smithy/signature-v4": "^5.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-W6hTSOPiSbh4IdTYVxN7xHjpCh0qvfQU1GKGBzGQm0ZEIOaMmWqiDEvFfyGYKmfBvumT8vHKxQRTX0av9omtIg=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.986.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.7", "@aws-sdk/types": "^3.973.1", "@smithy/protocol-http": "^5.3.8", "@smithy/signature-v4": "^5.3.8", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-Upw+rw7wCH93E6QWxqpAqJLrUmJYVUAWrk4tCOBnkeuwzGERZvJFL5UQ6TAJFj9T18Ih+vNFaACh8J5aP4oTBw=="],
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.985.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.7", "@aws-sdk/nested-clients": "3.985.0", "@aws-sdk/types": "^3.973.1", "@smithy/property-provider": "^4.2.8", "@smithy/shared-ini-file-loader": "^4.4.3", "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ=="],
 
@@ -178,7 +179,7 @@
 
     "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg=="],
 
-    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.985.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA=="],
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.986.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-Mqi79L38qi1gCG3adlVdbNrSxvcm1IPDLiJPA3OBypY5ewxUyWbaA3DD4goG+EwET6LSFgZJcRSIh6KBNpP5pA=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.4", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog=="],
 
@@ -401,6 +402,8 @@
     "@phonaria/phonetics-data": ["@phonaria/phonetics-data@workspace:packages/phonetics-data"],
 
     "@phonaria/ui": ["@phonaria/ui@workspace:packages/ui"],
+
+    "@playwright/test": ["@playwright/test@1.58.0", "", { "dependencies": { "playwright": "1.58.0" }, "bin": { "playwright": "cli.js" } }, "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.3", "", { "os": "android", "cpu": "arm" }, "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w=="],
 
@@ -678,7 +681,7 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
-    "bowser": ["bowser@2.13.1", "", {}, "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="],
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -876,6 +879,10 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "playwright": ["playwright@1.58.0", "", { "dependencies": { "playwright-core": "1.58.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ=="],
+
+    "playwright-core": ["playwright-core@1.58.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw=="],
+
     "po-parser": ["po-parser@1.0.2", "", {}, "sha512-yTIQL8PZy7V8c0psPoJUx7fayez+Mo/53MZgX9MPuPHx+Dt+sRPNuRbI+6Oqxnddhkd68x4Nlgon/zizL1Xg+w=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -1052,6 +1059,12 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@aws-sdk/client-sso/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.985.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA=="],
+
+    "@aws-sdk/middleware-user-agent/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.985.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA=="],
+
+    "@aws-sdk/nested-clients/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.985.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@formatjs/ecma402-abstract/@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
@@ -1089,6 +1102,8 @@
     "next/@next/env": ["@next/env@16.0.10", "", {}, "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"lint": "turbo run lint",
 		"dev": "turbo run dev",
 		"check-types": "turbo run check-types",
-		"test": "turbo run test"
+		"test": "turbo run test",
+		"e2e": "turbo run e2e"
 	},
 	"workspaces": [
 		"packages/*",

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,11 @@
 		},
 		"test": {
 			"dependsOn": ["^test"]
+		},
+		"e2e": {
+			"dependsOn": ["build"],
+			"cache": false,
+			"env": ["SKIP_RATE_LIMIT", "DATABASE_URL"]
 		}
 	}
 }


### PR DESCRIPTION
Sets up end-to-end testing with Playwright covering transcription, find-by-sound, and navigation flows. Includes Playwright configuration, a GitHub Actions workflow for CI automation on push to main, and lazy rate limiter initialization to support testing without Redis.

E2E tests validate core user workflows: transcribing text and viewing IPA output, searching words by phoneme patterns, and navigating between app pages and locales. Tests run automatically in CI with retries and trace capture on failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced end-to-end testing with Playwright, including suites for transcription, phoneme search, navigation, and locale flows.
  * Added e2e run commands (including UI and install variants).

* **Documentation**
  * Updated testing guidance to separate Vitest unit tests from Playwright E2E, with execution and CI details.

* **Build/Configuration**
  * Added E2E task orchestration and Playwright config; enabled optional rate-limit bypass for test runs.

* **Chores**
  * Updated ignore rules for E2E/test artifacts and added E2E scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->