### PR TITLE
fix(ui): resolve dark mode two-tone background

### DIFF
--- a/apps/web/src/app/[locale]/ipa-chart/_sections/intro-section.tsx
+++ b/apps/web/src/app/[locale]/ipa-chart/_sections/intro-section.tsx
@@ -9,7 +9,7 @@ export async function IntroSection({ locale }: Props) {
 	const t = await getTranslations({ locale, namespace: "ipa-chart.intro" });
 
 	return (
-		<section className="border-b bg-muted/30">
+		<section className="border-b bg-background-soft">
 			<div className="container mx-auto px-4 py-4">
 				<h1 className="text-base font-semibold tracking-tight">{t("title")}</h1>
 				<p className="mt-1 text-sm text-muted-foreground">{t("description")}</p>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -180,6 +180,9 @@
 	* {
 		@apply border-border outline-ring/50;
 	}
+	html {
+		@apply bg-background;
+	}
 	body {
 		@apply bg-background text-foreground;
 	}


### PR DESCRIPTION
## Summary
- Apply `bg-background` to `<html>` in globals.css to prevent CSS background propagation to the canvas, which caused a two-tone background split in dark mode production builds
- Replace `bg-muted/30` opacity modifier on the IPA chart intro section with `bg-background-soft` per style guidelines

## Test plan
- [ ] Deploy to Vercel preview and verify dark mode background is uniform on the lab app transcription page
- [ ] Verify dark mode background is uniform on the lab app consonants and vowels chart pages (no lighter bands at top/bottom)
- [ ] Verify light mode is unaffected on all pages
- [ ] Verify the IPA chart intro section on the web app still renders with a subtle distinct background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined intro section background styling for improved visual consistency
  * Enhanced default background color application across the application interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->