### PR TITLE
chore: configure repo for Claude Code worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,13 @@
 {
-  "worktree": {
-    "symlinkDirectories": [
-      "node_modules",
-      "apps/lab/node_modules",
-      "apps/web/node_modules",
-      "packages/audio-gen/node_modules",
-      "packages/helper-scripts/node_modules",
-      "packages/phonetics-data/node_modules",
-      "packages/ui/node_modules"
-    ]
-  }
+	"worktree": {
+		"symlinkDirectories": [
+			"node_modules",
+			"apps/lab/node_modules",
+			"apps/web/node_modules",
+			"packages/audio-gen/node_modules",
+			"packages/helper-scripts/node_modules",
+			"packages/phonetics-data/node_modules",
+			"packages/ui/node_modules"
+		]
+	}
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      "apps/lab/node_modules",
+      "apps/web/node_modules",
+      "packages/audio-gen/node_modules",
+      "packages/helper-scripts/node_modules",
+      "packages/phonetics-data/node_modules",
+      "packages/ui/node_modules"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ playwright/.cache/
 
 .codex
 
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json
+
 # Generated data files
 *.csv
 *.db

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,6 @@
+# Gitignored files copied into every worktree Claude Code creates.
+# Uses .gitignore syntax; only files that match AND are gitignored are copied.
+apps/web/.env.local
+apps/lab/.env.local
+packages/audio-gen/.env
+packages/helper-scripts/.env


### PR DESCRIPTION
Sets up phonaria for parallel work in Claude Code worktrees, mirroring the vita-os setup.

- **`.worktreeinclude`** — copies the four gitignored env files (`apps/web/.env.local`, `apps/lab/.env.local`, `packages/audio-gen/.env`, `packages/helper-scripts/.env`) into every new worktree so dev servers and scripts work immediately.
- **`.claude/settings.json`** — symlinks all seven workspace `node_modules` directories into new worktrees, so each worktree skips a full `bun install`.
- **`.gitignore`** — ignores `.claude/worktrees/` and `.claude/settings.local.json` so worktree checkouts and personal settings never get committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration for consistent development worktrees, including preservation of required local dependencies and settings.
  * Added rules to exclude local Claude Code files and worktree artifacts from version control.
  * Configured supported environment files to be copied into new worktrees when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->