### PR TITLE
feat(lab): practice scoring engine — normalization, strict check, alignment, raw-count contract

### DIFF
--- a/apps/lab/src/lib/practice/scoring.test.ts
+++ b/apps/lab/src/lib/practice/scoring.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import {
+	alignSequences,
+	normalizeAcceptedVariants,
+	normalizeVariant,
+	scoreWord,
+	stripStress,
+} from "./scoring";
+
+describe("stripStress", () => {
+	it("removes the stress digit from vowel tokens", () => {
+		expect(stripStress("AX0")).toBe("AX");
+		expect(stripStress("AU1")).toBe("AU");
+		expect(stripStress("OU2")).toBe("OU");
+	});
+
+	it("leaves consonant tokens unchanged", () => {
+		expect(stripStress("T")).toBe("T");
+		expect(stripStress("DH")).toBe("DH");
+	});
+});
+
+describe("normalizeVariant", () => {
+	it("splits a stored pronunciation into palette-space phoneme IDs", () => {
+		expect(normalizeVariant("T AX0 M EI1 T OU2")).toEqual(["T", "AX", "M", "EI", "T", "OU"]);
+	});
+
+	it("ignores extra whitespace", () => {
+		expect(normalizeVariant(" DH  AX0 ")).toEqual(["DH", "AX"]);
+	});
+});
+
+describe("normalizeAcceptedVariants", () => {
+	it("keeps phonemically distinct variants in CMU order", () => {
+		expect(normalizeAcceptedVariants(["DH AX0", "DH AH1", "DH I0"])).toEqual([
+			["DH", "AX"],
+			["DH", "AH"],
+			["DH", "I"],
+		]);
+	});
+
+	it("dedupes variants that collapse once stress is stripped", () => {
+		expect(normalizeAcceptedVariants(["R OU1 D", "R OU2 D"])).toEqual([["R", "OU", "D"]]);
+	});
+
+	it("keeps the first occurrence when deduping", () => {
+		const variants = normalizeAcceptedVariants(["B AE1 D", "B AE2 D", "B I1 D"]);
+		expect(variants).toEqual([
+			["B", "AE", "D"],
+			["B", "I", "D"],
+		]);
+	});
+});
+
+describe("alignSequences", () => {
+	it("returns all matches for identical sequences", () => {
+		expect(alignSequences(["S", "OU", "F", "AX"], ["S", "OU", "F", "AX"])).toEqual([
+			{ kind: "match", sound: "S" },
+			{ kind: "match", sound: "OU" },
+			{ kind: "match", sound: "F" },
+			{ kind: "match", sound: "AX" },
+		]);
+	});
+
+	it("reports a substitution for a single differing sound", () => {
+		expect(alignSequences(["S", "AH", "F", "AX"], ["S", "OU", "F", "AX"])).toEqual([
+			{ kind: "match", sound: "S" },
+			{ kind: "substitution", target: "OU", source: "AH" },
+			{ kind: "match", sound: "F" },
+			{ kind: "match", sound: "AX" },
+		]);
+	});
+
+	it("reports an omission when the learner skips a reference sound", () => {
+		expect(alignSequences(["S", "F", "AX"], ["S", "OU", "F", "AX"])).toEqual([
+			{ kind: "match", sound: "S" },
+			{ kind: "omission", target: "OU" },
+			{ kind: "match", sound: "F" },
+			{ kind: "match", sound: "AX" },
+		]);
+	});
+
+	it("reports an insertion when the learner adds an extra sound", () => {
+		expect(alignSequences(["S", "T", "OU", "F", "AX"], ["S", "OU", "F", "AX"])).toEqual([
+			{ kind: "match", sound: "S" },
+			{ kind: "insertion", source: "T" },
+			{ kind: "match", sound: "OU" },
+			{ kind: "match", sound: "F" },
+			{ kind: "match", sound: "AX" },
+		]);
+	});
+
+	it("prefers substitution over omission when costs tie", () => {
+		// learner [A] vs reference [B, C]: omission+substitution both cost 2 either
+		// way; the fixed backtrace pairs the learner sound with the LAST reference
+		// sound (substitution checked before omission walking from the end).
+		expect(alignSequences(["A"], ["B", "C"])).toEqual([
+			{ kind: "omission", target: "B" },
+			{ kind: "substitution", target: "C", source: "A" },
+		]);
+	});
+
+	it("renders a swap as two substitutions, never omission plus insertion", () => {
+		expect(alignSequences(["A", "B"], ["B", "A"])).toEqual([
+			{ kind: "substitution", target: "B", source: "A" },
+			{ kind: "substitution", target: "A", source: "B" },
+		]);
+	});
+
+	it("resolves ambiguous matches deterministically from the end of the word", () => {
+		// learner [A] vs reference [A, X, A]: the single A could match either
+		// reference A at equal cost; the fixed backtrace pairs it with the last.
+		expect(alignSequences(["A"], ["A", "X", "A"])).toEqual([
+			{ kind: "omission", target: "A" },
+			{ kind: "omission", target: "X" },
+			{ kind: "match", sound: "A" },
+		]);
+	});
+
+	it("is deterministic: identical inputs always produce identical ops", () => {
+		const first = alignSequences(["K", "AX", "T"], ["K", "AE", "T", "S"]);
+		const second = alignSequences(["K", "AX", "T"], ["K", "AE", "T", "S"]);
+		expect(first).toEqual(second);
+	});
+});
+
+describe("scoreWord", () => {
+	it("marks a word correct on strict equality with the only variant", () => {
+		const score = scoreWord(["S", "OU", "F", "AX"], ["S OU1 F AX0"]);
+		expect(score.correct).toBe(true);
+		expect(score.reference).toEqual(["S", "OU", "F", "AX"]);
+		expect(score.referenceIndex).toBe(0);
+		expect(score.hasAlternates).toBe(false);
+		expect(score.matched).toBe(4);
+		expect(score.learnerLength).toBe(4);
+		expect(score.referenceLength).toBe(4);
+	});
+
+	it("accepts any CMU variant, not just the first", () => {
+		const score = scoreWord(["DH", "AH"], ["DH AX0", "DH AH1", "DH I0"]);
+		expect(score.correct).toBe(true);
+		expect(score.referenceIndex).toBe(1);
+		expect(score.reference).toEqual(["DH", "AH"]);
+		expect(score.hasAlternates).toBe(true);
+	});
+
+	it("never scores AX/AH near-misses as correct", () => {
+		const score = scoreWord(["S", "OU", "F", "AH"], ["S OU1 F AX0"]);
+		expect(score.correct).toBe(false);
+		expect(score.ops).toContainEqual({ kind: "substitution", target: "AX", source: "AH" });
+	});
+
+	it("never scores AX/IX near-misses as correct", () => {
+		const score = scoreWord(["S", "OU", "F", "IX"], ["S OU1 F AX0"]);
+		expect(score.correct).toBe(false);
+		expect(score.ops).toContainEqual({ kind: "substitution", target: "AX", source: "IX" });
+	});
+
+	it("judges wrong answers against the closest variant", () => {
+		// learner is one edit from the second variant, two from the first
+		const score = scoreWord(
+			["T", "AX", "M", "A", "T", "AX"],
+			["T AX0 M EI1 T OU2", "T AX0 M A1 T OU2"],
+		);
+		expect(score.correct).toBe(false);
+		expect(score.referenceIndex).toBe(1);
+		expect(score.reference).toEqual(["T", "AX", "M", "A", "T", "OU"]);
+	});
+
+	it("breaks closest-variant ties by CMU order", () => {
+		// learner is exactly one substitution from each variant
+		const score = scoreWord(["B", "EH", "D"], ["B AE1 D", "B I1 D"]);
+		expect(score.correct).toBe(false);
+		expect(score.referenceIndex).toBe(0);
+		expect(score.reference).toEqual(["B", "AE", "D"]);
+	});
+
+	it("selects the closest variant after stress-strip deduping", () => {
+		// first two variants collapse into one; learner matches the collapsed form
+		const score = scoreWord(["R", "OU", "D"], ["R OU1 D", "R OU2 D", "R AA1 D"]);
+		expect(score.correct).toBe(true);
+		expect(score.referenceIndex).toBe(0);
+		expect(score.hasAlternates).toBe(true);
+	});
+
+	it("scores a blank answer as 0 matched over the full reference length", () => {
+		const score = scoreWord([], ["S OU1 F AX0"]);
+		expect(score.correct).toBe(false);
+		expect(score.matched).toBe(0);
+		expect(score.learnerLength).toBe(0);
+		expect(score.referenceLength).toBe(4);
+		expect(score.ops).toEqual([
+			{ kind: "omission", target: "S" },
+			{ kind: "omission", target: "OU" },
+			{ kind: "omission", target: "F" },
+			{ kind: "omission", target: "AX" },
+		]);
+	});
+
+	it("resolves blank-answer variant ties by CMU order", () => {
+		const score = scoreWord([], ["DH AX0", "DH AH1", "DH I0"]);
+		expect(score.referenceIndex).toBe(0);
+		expect(score.reference).toEqual(["DH", "AX"]);
+	});
+
+	it("tallies matched and total per reference sound", () => {
+		// reference T AX M EI T OU; learner misses EI and one T
+		const score = scoreWord(["T", "AX", "M", "OU"], ["T AX0 M EI1 T OU2"]);
+		expect(score.tallies).toEqual({
+			T: { matched: 1, total: 2 },
+			AX: { matched: 1, total: 1 },
+			M: { matched: 1, total: 1 },
+			EI: { matched: 0, total: 1 },
+			OU: { matched: 1, total: 1 },
+		});
+	});
+
+	it("tallies a fully correct word as all matched", () => {
+		const score = scoreWord(["DH", "AX"], ["DH AX0"]);
+		expect(score.tallies).toEqual({
+			DH: { matched: 1, total: 1 },
+			AX: { matched: 1, total: 1 },
+		});
+	});
+
+	it("counts insertions in learner length but not in tallies", () => {
+		const score = scoreWord(["S", "T", "OU", "F", "AX"], ["S OU1 F AX0"]);
+		expect(score.matched).toBe(4);
+		expect(score.learnerLength).toBe(5);
+		expect(score.referenceLength).toBe(4);
+		expect(score.tallies).toEqual({
+			S: { matched: 1, total: 1 },
+			OU: { matched: 1, total: 1 },
+			F: { matched: 1, total: 1 },
+			AX: { matched: 1, total: 1 },
+		});
+	});
+
+	it("returns raw counts only — no derived percentages or copy", () => {
+		const score = scoreWord(["DH", "AX"], ["DH AX0"]);
+		expect(Object.keys(score).sort()).toEqual([
+			"correct",
+			"hasAlternates",
+			"learnerLength",
+			"matched",
+			"ops",
+			"reference",
+			"referenceIndex",
+			"referenceLength",
+			"tallies",
+		]);
+	});
+
+	it("throws when no accepted pronunciations are given", () => {
+		expect(() => scoreWord(["DH", "AX"], [])).toThrow();
+	});
+});

--- a/apps/lab/src/lib/practice/scoring.test.ts
+++ b/apps/lab/src/lib/practice/scoring.test.ts
@@ -1,32 +1,21 @@
 import { describe, expect, it } from "vitest";
-import {
-	alignSequences,
-	normalizeAcceptedVariants,
-	normalizeVariant,
-	scoreWord,
-	stripStress,
-} from "./scoring";
+import { alignSequences, normalizeAcceptedVariants, normalizeVariant, scoreWord } from "./scoring";
 
-describe("stripStress", () => {
-	it("removes the stress digit from vowel tokens", () => {
-		expect(stripStress("AX0")).toBe("AX");
-		expect(stripStress("AU1")).toBe("AU");
-		expect(stripStress("OU2")).toBe("OU");
+describe("normalizeVariant", () => {
+	it("strips stress digits, yielding palette-space phoneme IDs", () => {
+		expect(normalizeVariant("T AX0 M EI1 T OU2")).toEqual(["T", "AX", "M", "EI", "T", "OU"]);
 	});
 
 	it("leaves consonant tokens unchanged", () => {
-		expect(stripStress("T")).toBe("T");
-		expect(stripStress("DH")).toBe("DH");
-	});
-});
-
-describe("normalizeVariant", () => {
-	it("splits a stored pronunciation into palette-space phoneme IDs", () => {
-		expect(normalizeVariant("T AX0 M EI1 T OU2")).toEqual(["T", "AX", "M", "EI", "T", "OU"]);
+		expect(normalizeVariant("DH AX0")).toEqual(["DH", "AX"]);
 	});
 
 	it("ignores extra whitespace", () => {
 		expect(normalizeVariant(" DH  AX0 ")).toEqual(["DH", "AX"]);
+	});
+
+	it("throws on tokens that are not known phoneme IDs", () => {
+		expect(() => normalizeVariant("DH QQ0")).toThrow();
 	});
 });
 

--- a/apps/lab/src/lib/practice/scoring.ts
+++ b/apps/lab/src/lib/practice/scoring.ts
@@ -1,0 +1,186 @@
+/**
+ * Topic-blind scoring for sound-sequence practice.
+ *
+ * Everything operates in phoneme-ID space: stored CMU pronunciations are
+ * normalized to the exact sequences the palette produces (stress digits
+ * stripped, variants deduped), and a learner's sequence is judged against
+ * them. The scorer returns raw counts only — it knows nothing about topics
+ * (e.g. what schwa is); topics filter the per-sound tallies downstream.
+ */
+
+/** One step in the alignment between a learner sequence and a reference. */
+export type AlignmentOp =
+	| { kind: "match"; sound: string }
+	| { kind: "substitution"; target: string; source: string }
+	| { kind: "omission"; target: string }
+	| { kind: "insertion"; source: string };
+
+export interface SoundTally {
+	matched: number;
+	total: number;
+}
+
+export interface WordScore {
+	/** Strict equality against a deduped accepted variant. */
+	correct: boolean;
+	/** The accepted variant the answer was judged against, in palette space. */
+	reference: string[];
+	/** Index of that variant in the deduped, CMU-ordered accepted list. */
+	referenceIndex: number;
+	/** Whether more than one deduped accepted variant exists. */
+	hasAlternates: boolean;
+	/** Full alignment against the chosen reference, in word order. */
+	ops: AlignmentOp[];
+	/** Count of match ops. */
+	matched: number;
+	learnerLength: number;
+	referenceLength: number;
+	/** Per reference sound: how many occurrences the learner matched. */
+	tallies: Record<string, SoundTally>;
+}
+
+/** Strips the trailing stress digit from a stored phoneme token. */
+export function stripStress(token: string): string {
+	return token.replace(/[0-2]$/, "");
+}
+
+/** Converts one stored CMU pronunciation into a palette-space sequence. */
+export function normalizeVariant(cmuVariant: string): string[] {
+	return cmuVariant
+		.split(" ")
+		.filter((token) => token.length > 0)
+		.map(stripStress);
+}
+
+/**
+ * Normalizes every stored variant and dedupes the results, preserving CMU
+ * order (first occurrence wins). Variants that differ only in stress
+ * collapse; phonemically distinct variants all remain accepted.
+ */
+export function normalizeAcceptedVariants(cmuVariants: string[]): string[][] {
+	const seen = new Set<string>();
+	const variants: string[][] = [];
+	for (const cmuVariant of cmuVariants) {
+		const sequence = normalizeVariant(cmuVariant);
+		const key = sequence.join(" ");
+		if (!seen.has(key)) {
+			seen.add(key);
+			variants.push(sequence);
+		}
+	}
+	return variants;
+}
+
+/**
+ * Aligns a learner sequence against a reference under uniform-cost edit
+ * distance (substitution, omission, insertion each cost 1).
+ *
+ * Deterministic by construction: the backtrace walks from the end of the
+ * word and, wherever costs tie, prefers substitution (or match), then
+ * omission, then insertion — so identical answers always render identically.
+ */
+export function alignSequences(learner: string[], reference: string[]): AlignmentOp[] {
+	const m = learner.length;
+	const n = reference.length;
+
+	// dp[i][j] = edit distance between learner[0..i) and reference[0..j)
+	const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+	for (let i = 1; i <= m; i++) dp[i][0] = i;
+	for (let j = 1; j <= n; j++) dp[0][j] = j;
+	for (let i = 1; i <= m; i++) {
+		for (let j = 1; j <= n; j++) {
+			const subCost = learner[i - 1] === reference[j - 1] ? 0 : 1;
+			dp[i][j] = Math.min(dp[i - 1][j - 1] + subCost, dp[i][j - 1] + 1, dp[i - 1][j] + 1);
+		}
+	}
+
+	const reversed: AlignmentOp[] = [];
+	let i = m;
+	let j = n;
+	while (i > 0 || j > 0) {
+		const subCost = i > 0 && j > 0 && learner[i - 1] === reference[j - 1] ? 0 : 1;
+		if (i > 0 && j > 0 && dp[i][j] === dp[i - 1][j - 1] + subCost) {
+			reversed.push(
+				subCost === 0
+					? { kind: "match", sound: reference[j - 1] }
+					: { kind: "substitution", target: reference[j - 1], source: learner[i - 1] },
+			);
+			i--;
+			j--;
+		} else if (j > 0 && dp[i][j] === dp[i][j - 1] + 1) {
+			reversed.push({ kind: "omission", target: reference[j - 1] });
+			j--;
+		} else {
+			reversed.push({ kind: "insertion", source: learner[i - 1] });
+			i--;
+		}
+	}
+	return reversed.reverse();
+}
+
+function editDistance(learner: string[], reference: string[]): number {
+	const m = learner.length;
+	const n = reference.length;
+	let previous = Array.from({ length: n + 1 }, (_, j) => j);
+	for (let i = 1; i <= m; i++) {
+		const current = new Array<number>(n + 1);
+		current[0] = i;
+		for (let j = 1; j <= n; j++) {
+			const subCost = learner[i - 1] === reference[j - 1] ? 0 : 1;
+			current[j] = Math.min(previous[j - 1] + subCost, current[j - 1] + 1, previous[j] + 1);
+		}
+		previous = current;
+	}
+	return previous[n];
+}
+
+/**
+ * Scores a learner's palette sequence against a word's stored CMU
+ * pronunciations. A blank answer (empty learner sequence) flows through the
+ * ordinary path: every reference sound becomes an omission, 0 matched over
+ * the full reference length.
+ */
+export function scoreWord(learner: string[], cmuVariants: string[]): WordScore {
+	const accepted = normalizeAcceptedVariants(cmuVariants);
+	if (accepted.length === 0) {
+		throw new Error("scoreWord requires at least one accepted pronunciation");
+	}
+
+	let referenceIndex = 0;
+	let bestDistance = Number.POSITIVE_INFINITY;
+	for (let index = 0; index < accepted.length; index++) {
+		const distance = editDistance(learner, accepted[index]);
+		if (distance < bestDistance) {
+			bestDistance = distance;
+			referenceIndex = index;
+		}
+	}
+
+	const reference = accepted[referenceIndex];
+	const ops = alignSequences(learner, reference);
+
+	const tallies: Record<string, SoundTally> = {};
+	for (const sound of reference) {
+		tallies[sound] ??= { matched: 0, total: 0 };
+		tallies[sound].total++;
+	}
+	let matched = 0;
+	for (const op of ops) {
+		if (op.kind === "match") {
+			matched++;
+			tallies[op.sound].matched++;
+		}
+	}
+
+	return {
+		correct: bestDistance === 0,
+		reference,
+		referenceIndex,
+		hasAlternates: accepted.length > 1,
+		ops,
+		matched,
+		learnerLength: learner.length,
+		referenceLength: reference.length,
+		tallies,
+	};
+}

--- a/apps/lab/src/lib/practice/scoring.ts
+++ b/apps/lab/src/lib/practice/scoring.ts
@@ -8,6 +8,8 @@
  * (e.g. what schwa is); topics filter the per-sound tallies downstream.
  */
 
+import { extractBasePhonemeId } from "@phonaria/phonetics-data";
+
 /** One step in the alignment between a learner sequence and a reference. */
 export type AlignmentOp =
 	| { kind: "match"; sound: string }
@@ -39,17 +41,15 @@ export interface WordScore {
 	tallies: Record<string, SoundTally>;
 }
 
-/** Strips the trailing stress digit from a stored phoneme token. */
-export function stripStress(token: string): string {
-	return token.replace(/[0-2]$/, "");
-}
-
-/** Converts one stored CMU pronunciation into a palette-space sequence. */
+/**
+ * Converts one stored CMU pronunciation into a palette-space sequence.
+ * Throws on tokens that aren't known phoneme IDs.
+ */
 export function normalizeVariant(cmuVariant: string): string[] {
 	return cmuVariant
 		.split(" ")
 		.filter((token) => token.length > 0)
-		.map(stripStress);
+		.map((token) => extractBasePhonemeId(token));
 }
 
 /**
@@ -118,22 +118,6 @@ export function alignSequences(learner: string[], reference: string[]): Alignmen
 	return reversed.reverse();
 }
 
-function editDistance(learner: string[], reference: string[]): number {
-	const m = learner.length;
-	const n = reference.length;
-	let previous = Array.from({ length: n + 1 }, (_, j) => j);
-	for (let i = 1; i <= m; i++) {
-		const current = new Array<number>(n + 1);
-		current[0] = i;
-		for (let j = 1; j <= n; j++) {
-			const subCost = learner[i - 1] === reference[j - 1] ? 0 : 1;
-			current[j] = Math.min(previous[j - 1] + subCost, current[j - 1] + 1, previous[j] + 1);
-		}
-		previous = current;
-	}
-	return previous[n];
-}
-
 /**
  * Scores a learner's palette sequence against a word's stored CMU
  * pronunciations. A blank answer (empty learner sequence) flows through the
@@ -147,17 +131,20 @@ export function scoreWord(learner: string[], cmuVariants: string[]): WordScore {
 	}
 
 	let referenceIndex = 0;
+	let bestOps: AlignmentOp[] = [];
 	let bestDistance = Number.POSITIVE_INFINITY;
 	for (let index = 0; index < accepted.length; index++) {
-		const distance = editDistance(learner, accepted[index]);
+		const ops = alignSequences(learner, accepted[index]);
+		const distance = ops.filter((op) => op.kind !== "match").length;
 		if (distance < bestDistance) {
 			bestDistance = distance;
+			bestOps = ops;
 			referenceIndex = index;
 		}
 	}
 
 	const reference = accepted[referenceIndex];
-	const ops = alignSequences(learner, reference);
+	const ops = bestOps;
 
 	const tallies: Record<string, SoundTally> = {};
 	for (const sound of reference) {


### PR DESCRIPTION
Closes #143. Part of #140 (Practice PRD, implementation step 4).

## What

Adds the topic-blind scorer at `apps/lab/src/lib/practice/scoring.ts` with sibling node-env tests. Pure module, entirely in phoneme-ID space:

- **Normalization** — `normalizeVariant` / `normalizeAcceptedVariants`: stress digits stripped via `extractBasePhonemeId` (validated against the phoneme map), variants deduped with CMU order preserved. `AX` stays distinct from `AH`.
- **Primary score** — correct only on strict equality (distance 0) against any deduped accepted variant; no near-miss leniency; no variant ranking.
- **Alignment** — uniform-cost edit distance (sub/ins/del each 1); deterministic backtrace preferring substitution → omission → insertion; closest-variant selection with CMU-order tie-break.
- **Contract** — raw counts only: chosen reference + index, has-alternates flag, full op list with sounds, per-reference-sound tallies, matched / learner-length / reference-length for consumer-side pooled sound accuracy. Blanks flow through the ordinary path (all omissions, 0 matched over the full reference length).

## Verification

- 31 scoring tests cover every acceptance criterion, including backtrace-order and tie-break determinism
- `bun run check-types`, Biome, and the full lab suite (124 tests) pass
- Two-axis code review (standards + spec) run; findings addressed in the second commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pronunciation scoring that evaluates learner phoneme sequences against accepted pronunciation variants.
  * Supports alternate pronunciations, stress normalization, invalid-phoneme handling, and detailed sound-level feedback.
  * Provides alignment results showing matches, omissions, insertions, and substitutions.
* **Tests**
  * Added comprehensive coverage for pronunciation normalization, sequence alignment, scoring accuracy, edge cases, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->