### PR TITLE
feat(lab): practice engine — word pool, topic seam, session generator (schwa)

### DIFF
--- a/apps/lab/src/lib/practice/session-generator.test.ts
+++ b/apps/lab/src/lib/practice/session-generator.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { generateSession } from "./session-generator";
 import type { SyllableBand } from "./topics/types";
-import type { PoolWord, TargetSoundPosition } from "./word-pool";
+import type { PoolWord, TopicSoundPosition } from "./word-pool";
 
 function makeWord(
 	word: string,
 	syllableCount: number,
-	targetSoundPositions: TargetSoundPosition[] = ["initial"],
+	topicSoundPositions: TopicSoundPosition[] = ["initial"],
 ): PoolWord {
 	return {
 		word,
@@ -14,8 +14,8 @@ function makeWord(
 		rank: 0,
 		frequencyTier: "top-1k",
 		syllableCount,
-		targetSoundCount: targetSoundPositions.length,
-		targetSoundPositions,
+		topicSoundCount: topicSoundPositions.length,
+		topicSoundPositions,
 	};
 }
 
@@ -44,7 +44,7 @@ const FIVE_SLOTS: SyllableBand[] = [
 
 function makeBroadPool(): PoolWord[] {
 	const pool: PoolWord[] = [];
-	const positions: TargetSoundPosition[][] = [["initial"], ["medial"], ["final"]];
+	const positions: TopicSoundPosition[][] = [["initial"], ["medial"], ["final"]];
 	for (let syllables = 2; syllables <= 5; syllables++) {
 		for (let i = 0; i < 15; i++) {
 			pool.push(makeWord(`w${syllables}s${i}`, syllables, positions[i % positions.length]));
@@ -91,7 +91,7 @@ describe("generateSession", () => {
 		}
 	});
 
-	it("prefers target-sound variety unseen in the session", () => {
+	it("prefers topic-sound variety unseen in the session", () => {
 		const pool = [
 			makeWord("aaa-initial", 2, ["initial"]),
 			makeWord("bbb-final", 2, ["final"]),

--- a/apps/lab/src/lib/practice/session-generator.test.ts
+++ b/apps/lab/src/lib/practice/session-generator.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { generateSession } from "./session-generator";
+import type { SyllableBand } from "./topics/types";
+import type { PoolWord, TargetSoundPosition } from "./word-pool";
+
+function makeWord(
+	word: string,
+	syllableCount: number,
+	targetSoundPositions: TargetSoundPosition[] = ["initial"],
+): PoolWord {
+	return {
+		word,
+		variants: ["AX0 B AU1 T"],
+		rank: 0,
+		frequencyTier: "top-1k",
+		syllableCount,
+		targetSoundCount: targetSoundPositions.length,
+		targetSoundPositions,
+	};
+}
+
+/** Deterministic LCG so tests can assert exact reproducibility. */
+function seededRng(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state * 1664525 + 1013904223) >>> 0;
+		return state / 2 ** 32;
+	};
+}
+
+/** Returns queued values in order, then a constant 0.5 when exhausted. */
+function queuedRng(values: number[]): () => number {
+	let i = 0;
+	return () => (i < values.length ? values[i++] : 0.5);
+}
+
+const FIVE_SLOTS: SyllableBand[] = [
+	{ min: 2, max: 2 },
+	{ min: 2, max: 3 },
+	{ min: 3, max: 3 },
+	{ min: 3, max: 4 },
+	{ min: 4, max: null },
+];
+
+function makeBroadPool(): PoolWord[] {
+	const pool: PoolWord[] = [];
+	const positions: TargetSoundPosition[][] = [["initial"], ["medial"], ["final"]];
+	for (let syllables = 2; syllables <= 5; syllables++) {
+		for (let i = 0; i < 15; i++) {
+			pool.push(makeWord(`w${syllables}s${i}`, syllables, positions[i % positions.length]));
+		}
+	}
+	return pool;
+}
+
+describe("generateSession", () => {
+	it("is deterministic under an injected RNG", () => {
+		const pool = makeBroadPool();
+		const first = generateSession(pool, FIVE_SLOTS, seededRng(42));
+		const second = generateSession(pool, FIVE_SLOTS, seededRng(42));
+		expect(first.map((w) => w.word)).toEqual(second.map((w) => w.word));
+	});
+
+	it("fills each slot from its syllable band and never repeats a word", () => {
+		const pool = makeBroadPool();
+		for (let seed = 0; seed < 100; seed++) {
+			const session = generateSession(pool, FIVE_SLOTS, seededRng(seed));
+			expect(session).toHaveLength(5);
+			expect(new Set(session.map((w) => w.word)).size).toBe(5);
+			session.forEach((word, slot) => {
+				const band = FIVE_SLOTS[slot];
+				expect(word.syllableCount).toBeGreaterThanOrEqual(band.min);
+				if (band.max !== null) {
+					expect(word.syllableCount).toBeLessThanOrEqual(band.max);
+				}
+			});
+		}
+	});
+
+	it("dedupes across overlapping bands even when a band has a single fresh word", () => {
+		// Slot 2's band overlaps slot 1's; only two 2-syllable words exist, so
+		// slot 2 must take whichever word slot 1 left behind.
+		const pool = [makeWord("alpha", 2), makeWord("beta", 2)];
+		const slots: SyllableBand[] = [
+			{ min: 2, max: 2 },
+			{ min: 2, max: 2 },
+		];
+		for (let seed = 0; seed < 20; seed++) {
+			const session = generateSession(pool, slots, seededRng(seed));
+			expect(new Set(session.map((w) => w.word)).size).toBe(2);
+		}
+	});
+
+	it("prefers target-sound variety unseen in the session", () => {
+		const pool = [
+			makeWord("aaa-initial", 2, ["initial"]),
+			makeWord("bbb-final", 2, ["final"]),
+			makeWord("ccc-initial", 2, ["initial"]),
+		];
+		const slots: SyllableBand[] = [
+			{ min: 2, max: 2 },
+			{ min: 2, max: 2 },
+		];
+		// Slot 1: draw index 0 → aaa-initial (fresh variety, accepted).
+		// Slot 2: draw index 1 → ccc-initial (variety already seen) → redraw
+		// index 0 → bbb-final (fresh variety, accepted).
+		const session = generateSession(pool, slots, queuedRng([0, 0.99, 0]));
+		expect(session.map((w) => w.word)).toEqual(["aaa-initial", "bbb-final"]);
+	});
+
+	it("treats variety as a tie-breaker, never a quota", () => {
+		// Every candidate shares the same variety facets; the slot must still
+		// fill rather than starve hunting for variety.
+		const pool = [
+			makeWord("aaa", 2, ["initial"]),
+			makeWord("bbb", 2, ["initial"]),
+			makeWord("ccc", 2, ["initial"]),
+		];
+		const slots: SyllableBand[] = [
+			{ min: 2, max: 2 },
+			{ min: 2, max: 2 },
+		];
+		const session = generateSession(pool, slots, seededRng(7));
+		expect(session).toHaveLength(2);
+		expect(new Set(session.map((w) => w.word)).size).toBe(2);
+	});
+
+	it("throws when a slot's band has no candidates", () => {
+		const pool = [makeWord("alpha", 2)];
+		expect(() => generateSession(pool, [{ min: 4, max: null }], seededRng(1))).toThrow(
+			/no eligible words/i,
+		);
+	});
+});

--- a/apps/lab/src/lib/practice/session-generator.ts
+++ b/apps/lab/src/lib/practice/session-generator.ts
@@ -1,6 +1,6 @@
 /**
  * Session generation: a pure function of (pool, slot spec, rng). Each slot
- * draws randomly from its syllable band; target-sound position/count act as
+ * draws randomly from its syllable band; topic-sound position/count act as
  * soft variety tie-breakers, never quotas; a session never repeats a word;
  * memoryless across sessions (#140).
  */
@@ -17,10 +17,10 @@ export type SessionRng = () => number;
 const VARIETY_REDRAWS = 4;
 
 function varietyKey(word: PoolWord): string {
-	return `${word.targetSoundCount}:${word.targetSoundPositions.join("+")}`;
+	return `${word.topicSoundCount}:${word.topicSoundPositions.join("+")}`;
 }
 
-function isInBand(word: PoolWord, band: SyllableBand): boolean {
+export function isInSyllableBand(word: PoolWord, band: SyllableBand): boolean {
 	return word.syllableCount >= band.min && (band.max === null || word.syllableCount <= band.max);
 }
 
@@ -29,13 +29,13 @@ function drawSlot(
 	seenVariety: ReadonlySet<string>,
 	rng: SessionRng,
 ): PoolWord {
-	let firstDraw: PoolWord | null = null;
-	for (let attempt = 0; attempt <= VARIETY_REDRAWS; attempt++) {
+	const firstDraw = candidates[Math.floor(rng() * candidates.length)];
+	if (!seenVariety.has(varietyKey(firstDraw))) return firstDraw;
+	for (let attempt = 0; attempt < VARIETY_REDRAWS; attempt++) {
 		const candidate = candidates[Math.floor(rng() * candidates.length)];
-		firstDraw ??= candidate;
 		if (!seenVariety.has(varietyKey(candidate))) return candidate;
 	}
-	return firstDraw as PoolWord;
+	return firstDraw;
 }
 
 /**
@@ -52,7 +52,9 @@ export function generateSession(
 	const seenVariety = new Set<string>();
 
 	for (const band of slots) {
-		const candidates = pool.filter((word) => isInBand(word, band) && !usedWords.has(word.word));
+		const candidates = pool.filter(
+			(word) => isInSyllableBand(word, band) && !usedWords.has(word.word),
+		);
 		if (candidates.length === 0) {
 			throw new Error(`No eligible words for slot band ${band.min}–${band.max ?? "∞"} syllables`);
 		}

--- a/apps/lab/src/lib/practice/session-generator.ts
+++ b/apps/lab/src/lib/practice/session-generator.ts
@@ -1,0 +1,66 @@
+/**
+ * Session generation: a pure function of (pool, slot spec, rng). Each slot
+ * draws randomly from its syllable band; target-sound position/count act as
+ * soft variety tie-breakers, never quotas; a session never repeats a word;
+ * memoryless across sessions (#140).
+ */
+import type { SyllableBand } from "./topics/types";
+import type { PoolWord } from "./word-pool";
+
+/** Injectable random source returning values in [0, 1). */
+export type SessionRng = () => number;
+
+/**
+ * Extra draws a slot may spend looking for a word whose variety facets are
+ * unseen in the session before settling for its first draw.
+ */
+const VARIETY_REDRAWS = 4;
+
+function varietyKey(word: PoolWord): string {
+	return `${word.targetSoundCount}:${word.targetSoundPositions.join("+")}`;
+}
+
+function isInBand(word: PoolWord, band: SyllableBand): boolean {
+	return word.syllableCount >= band.min && (band.max === null || word.syllableCount <= band.max);
+}
+
+function drawSlot(
+	candidates: PoolWord[],
+	seenVariety: ReadonlySet<string>,
+	rng: SessionRng,
+): PoolWord {
+	let firstDraw: PoolWord | null = null;
+	for (let attempt = 0; attempt <= VARIETY_REDRAWS; attempt++) {
+		const candidate = candidates[Math.floor(rng() * candidates.length)];
+		firstDraw ??= candidate;
+		if (!seenVariety.has(varietyKey(candidate))) return candidate;
+	}
+	return firstDraw as PoolWord;
+}
+
+/**
+ * Draws one word per slot, in slot order. Throws when a band has no unused
+ * candidates — a data-shape failure the band-depth CI test exists to prevent.
+ */
+export function generateSession(
+	pool: readonly PoolWord[],
+	slots: readonly SyllableBand[],
+	rng: SessionRng,
+): PoolWord[] {
+	const session: PoolWord[] = [];
+	const usedWords = new Set<string>();
+	const seenVariety = new Set<string>();
+
+	for (const band of slots) {
+		const candidates = pool.filter((word) => isInBand(word, band) && !usedWords.has(word.word));
+		if (candidates.length === 0) {
+			throw new Error(`No eligible words for slot band ${band.min}–${band.max ?? "∞"} syllables`);
+		}
+		const picked = drawSlot(candidates, seenVariety, rng);
+		session.push(picked);
+		usedWords.add(picked.word);
+		seenVariety.add(varietyKey(picked));
+	}
+
+	return session;
+}

--- a/apps/lab/src/lib/practice/topics/index.test.ts
+++ b/apps/lab/src/lib/practice/topics/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getTopic, listTopics } from "./index";
+
+describe("topic registry", () => {
+	it("resolves the schwa topic by slug", () => {
+		expect(getTopic("schwa")?.id).toBe("schwa");
+	});
+
+	it("returns undefined for unknown slugs", () => {
+		expect(getTopic("clusters")).toBeUndefined();
+	});
+
+	it("lists every registered topic", () => {
+		expect(listTopics().map((t) => t.id)).toEqual(["schwa"]);
+	});
+});

--- a/apps/lab/src/lib/practice/topics/index.ts
+++ b/apps/lab/src/lib/practice/topics/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Topic registry — the only wiring point for Practice topics. Adding a topic
+ * means one folder exporting a TopicDefinition plus one entry here; the
+ * engine, scoreboard, and review UI never change.
+ */
+import { SchwaTopic } from "./schwa";
+import type { TopicDefinition } from "./types";
+
+const topics: readonly TopicDefinition[] = [SchwaTopic];
+
+export function getTopic(slug: string): TopicDefinition | undefined {
+	return topics.find((topic) => topic.id === slug);
+}
+
+export function listTopics(): readonly TopicDefinition[] {
+	return topics;
+}

--- a/apps/lab/src/lib/practice/topics/schwa/index.test.ts
+++ b/apps/lab/src/lib/practice/topics/schwa/index.test.ts
@@ -1,5 +1,6 @@
 import { EnglishCuratedTop10k } from "@phonaria/phonetics-data/data/en/curated-10k";
 import { describe, expect, it } from "vitest";
+import { isInSyllableBand } from "../../session-generator";
 import { deriveWordPool, loadWordPoolForTopic } from "../../word-pool";
 import { everyVariantContainsSchwa, SchwaTopic } from "./index";
 
@@ -20,9 +21,9 @@ describe("everyVariantContainsSchwa", () => {
 });
 
 describe("SchwaTopic", () => {
-	it("targets AX and defines five session slots", () => {
+	it("teaches AX and defines five session slots", () => {
 		expect(SchwaTopic.id).toBe("schwa");
-		expect(SchwaTopic.targetSounds).toEqual(["AX"]);
+		expect(SchwaTopic.topicSounds).toEqual(["AX"]);
 		expect(SchwaTopic.slotSpec).toHaveLength(5);
 	});
 });
@@ -31,17 +32,16 @@ describe("schwa word pool over shipped top-10k data", () => {
 	const pool = deriveWordPool(EnglishCuratedTop10k, SchwaTopic);
 
 	it("yields the expected pool size (~3,373 words)", () => {
-		expect(pool.length).toBeGreaterThan(3_000);
-		expect(pool.length).toBeLessThan(3_800);
+		// Pins the shipped top-10k data. If the data is regenerated, update this
+		// deliberately after confirming band depths still hold.
+		expect(pool).toHaveLength(3_373);
 	});
 
 	it("keeps every syllable band comfortably above slot demand", () => {
 		// A session draws at most 2 words per band; require a wide margin so
 		// data regeneration cannot silently starve a slot.
 		for (const band of SchwaTopic.slotSpec) {
-			const depth = pool.filter(
-				(w) => w.syllableCount >= band.min && (band.max === null || w.syllableCount <= band.max),
-			).length;
+			const depth = pool.filter((w) => isInSyllableBand(w, band)).length;
 			expect(depth, `band ${band.min}–${band.max ?? "∞"}`).toBeGreaterThan(200);
 		}
 	});

--- a/apps/lab/src/lib/practice/topics/schwa/index.test.ts
+++ b/apps/lab/src/lib/practice/topics/schwa/index.test.ts
@@ -1,0 +1,53 @@
+import { EnglishCuratedTop10k } from "@phonaria/phonetics-data/data/en/curated-10k";
+import { describe, expect, it } from "vitest";
+import { deriveWordPool, loadWordPoolForTopic } from "../../word-pool";
+import { everyVariantContainsSchwa, SchwaTopic } from "./index";
+
+describe("everyVariantContainsSchwa", () => {
+	it("accepts words whose every variant contains schwa", () => {
+		expect(everyVariantContainsSchwa(["AX0 B AU1 T"])).toBe(true);
+		expect(everyVariantContainsSchwa(["B AX0 N AE1 N AX0", "B AX0 N AA1 N AX0"])).toBe(true);
+	});
+
+	it("rejects words where any variant lacks schwa — the learner could dodge the sound", () => {
+		expect(everyVariantContainsSchwa(["DH AX0", "DH AH1"])).toBe(false);
+		expect(everyVariantContainsSchwa(["K AE1 T"])).toBe(false);
+	});
+
+	it("rejects an empty variant list", () => {
+		expect(everyVariantContainsSchwa([])).toBe(false);
+	});
+});
+
+describe("SchwaTopic", () => {
+	it("targets AX and defines five session slots", () => {
+		expect(SchwaTopic.id).toBe("schwa");
+		expect(SchwaTopic.targetSounds).toEqual(["AX"]);
+		expect(SchwaTopic.slotSpec).toHaveLength(5);
+	});
+});
+
+describe("schwa word pool over shipped top-10k data", () => {
+	const pool = deriveWordPool(EnglishCuratedTop10k, SchwaTopic);
+
+	it("yields the expected pool size (~3,373 words)", () => {
+		expect(pool.length).toBeGreaterThan(3_000);
+		expect(pool.length).toBeLessThan(3_800);
+	});
+
+	it("keeps every syllable band comfortably above slot demand", () => {
+		// A session draws at most 2 words per band; require a wide margin so
+		// data regeneration cannot silently starve a slot.
+		for (const band of SchwaTopic.slotSpec) {
+			const depth = pool.filter(
+				(w) => w.syllableCount >= band.min && (band.max === null || w.syllableCount <= band.max),
+			).length;
+			expect(depth, `band ${band.min}–${band.max ?? "∞"}`).toBeGreaterThan(200);
+		}
+	});
+
+	it("loads the same pool through the tier-2 façade", async () => {
+		const loaded = await loadWordPoolForTopic(SchwaTopic);
+		expect(loaded.length).toBe(pool.length);
+	});
+});

--- a/apps/lab/src/lib/practice/topics/schwa/index.ts
+++ b/apps/lab/src/lib/practice/topics/schwa/index.ts
@@ -1,0 +1,37 @@
+import { tryExtractBasePhonemeId } from "@phonaria/phonetics-data";
+import type { TopicDefinition } from "../types";
+
+/**
+ * A word qualifies only when every CMU variant contains schwa — if only some
+ * variants had it, a learner could dodge the target sound entirely.
+ */
+export function everyVariantContainsSchwa(variants: readonly string[]): boolean {
+	return (
+		variants.length > 0 &&
+		variants.every((variant) =>
+			variant.split(" ").some((token) => tryExtractBasePhonemeId(token) === "AX"),
+		)
+	);
+}
+
+export const SchwaTopic: TopicDefinition = {
+	id: "schwa",
+	targetSounds: ["AX"],
+	isEligibleWord: everyVariantContainsSchwa,
+	slotSpec: [
+		{ min: 2, max: 2 },
+		{ min: 2, max: 3 },
+		{ min: 3, max: 3 },
+		{ min: 3, max: 4 },
+		{ min: 4, max: null },
+	],
+	display: {
+		kicker: "Practice",
+		heading: "Schwa",
+		description:
+			"/ə/ is the most common vowel sound in English — and spelling never tells you where it hides. You'll get five words. Build each one's full sound sequence from its sounds, then see how you did at the end.",
+		startLabel: "Start session",
+	},
+	// Stub until the lesson catalog lands (#140, implementation step 9).
+	lessonCatalog: [],
+};

--- a/apps/lab/src/lib/practice/topics/schwa/index.ts
+++ b/apps/lab/src/lib/practice/topics/schwa/index.ts
@@ -3,7 +3,7 @@ import type { TopicDefinition } from "../types";
 
 /**
  * A word qualifies only when every CMU variant contains schwa — if only some
- * variants had it, a learner could dodge the target sound entirely.
+ * variants had it, a learner could dodge the topic sound entirely.
  */
 export function everyVariantContainsSchwa(variants: readonly string[]): boolean {
 	return (
@@ -16,7 +16,7 @@ export function everyVariantContainsSchwa(variants: readonly string[]): boolean 
 
 export const SchwaTopic: TopicDefinition = {
 	id: "schwa",
-	targetSounds: ["AX"],
+	topicSounds: ["AX"],
 	isEligibleWord: everyVariantContainsSchwa,
 	slotSpec: [
 		{ min: 2, max: 2 },

--- a/apps/lab/src/lib/practice/topics/types.ts
+++ b/apps/lab/src/lib/practice/topics/types.ts
@@ -23,7 +23,7 @@ export interface TopicDefinition {
 	/** Registry key, also the route slug under /practice/[topic]. */
 	id: string;
 	/** Sounds the topic teaches; word-pool facets are computed against these. */
-	targetSounds: readonly PhonemeSymbolId[];
+	topicSounds: readonly PhonemeSymbolId[];
 	/**
 	 * Topic-specific eligibility over a word's CMU variants. Composed with the
 	 * engine-owned word-suitability filter — it never re-implements it.

--- a/apps/lab/src/lib/practice/topics/types.ts
+++ b/apps/lab/src/lib/practice/topics/types.ts
@@ -1,0 +1,41 @@
+import type { PhonemeSymbolId } from "@phonaria/phonetics-data";
+
+/**
+ * Inclusive syllable-count band for one session slot.
+ * `max: null` means unbounded (e.g. "4+ syllables").
+ */
+export interface SyllableBand {
+	min: number;
+	max: number | null;
+}
+
+/** Placeholder until the lesson catalog lands (#140, implementation step 9). */
+export interface LessonPattern {
+	id: string;
+}
+
+/**
+ * Everything the Practice engine needs to run one topic. The topic registry
+ * (`topics/index.ts`) is the only wiring point: adding a topic means one
+ * folder exporting a TopicDefinition plus one registry entry.
+ */
+export interface TopicDefinition {
+	/** Registry key, also the route slug under /practice/[topic]. */
+	id: string;
+	/** Sounds the topic teaches; word-pool facets are computed against these. */
+	targetSounds: readonly PhonemeSymbolId[];
+	/**
+	 * Topic-specific eligibility over a word's CMU variants. Composed with the
+	 * engine-owned word-suitability filter — it never re-implements it.
+	 */
+	isEligibleWord: (variants: readonly string[]) => boolean;
+	/** Ordered per-slot syllable bands for a session. */
+	slotSpec: readonly SyllableBand[];
+	display: {
+		kicker: string;
+		heading: string;
+		description: string;
+		startLabel: string;
+	};
+	lessonCatalog: readonly LessonPattern[];
+}

--- a/apps/lab/src/lib/practice/word-pool.test.ts
+++ b/apps/lab/src/lib/practice/word-pool.test.ts
@@ -21,7 +21,7 @@ function makeData(words: Record<string, string[]>): CuratedWordData {
 function makeTopic(): TopicDefinition {
 	return {
 		id: "test-topic",
-		targetSounds: ["AX"],
+		topicSounds: ["AX"],
 		isEligibleWord: (variants) =>
 			variants.every((v) => v.split(" ").some((t) => t.replace(/[012]$/, "") === "AX")),
 		slotSpec: [],
@@ -71,7 +71,7 @@ describe("deriveWordPool", () => {
 		expect(pool.map((w) => w.word)).toEqual(["about"]);
 	});
 
-	it("computes syllable count, target-sound count, and positions from the first variant", () => {
+	it("computes syllable count, topic-sound count, and positions from the first variant", () => {
 		const data = makeData({
 			about: ["AX0 B AU1 T"],
 			banana: ["B AX0 N AE1 N AX0"],
@@ -82,17 +82,17 @@ describe("deriveWordPool", () => {
 
 		const about = byWord.get("about");
 		expect(about?.syllableCount).toBe(2);
-		expect(about?.targetSoundCount).toBe(1);
-		expect(about?.targetSoundPositions).toEqual(["initial"]);
+		expect(about?.topicSoundCount).toBe(1);
+		expect(about?.topicSoundPositions).toEqual(["initial"]);
 
 		const banana = byWord.get("banana");
 		expect(banana?.syllableCount).toBe(3);
-		expect(banana?.targetSoundCount).toBe(2);
-		expect(banana?.targetSoundPositions).toEqual(["initial", "final"]);
+		expect(banana?.topicSoundCount).toBe(2);
+		expect(banana?.topicSoundPositions).toEqual(["initial", "final"]);
 
 		const believer = byWord.get("believer");
 		expect(believer?.syllableCount).toBe(3);
-		expect(believer?.targetSoundPositions).toEqual(["medial"]);
+		expect(believer?.topicSoundPositions).toEqual(["medial"]);
 	});
 
 	it("records frequency rank and tier from data order", () => {

--- a/apps/lab/src/lib/practice/word-pool.test.ts
+++ b/apps/lab/src/lib/practice/word-pool.test.ts
@@ -1,0 +1,119 @@
+import type { CuratedWordData } from "@phonaria/phonetics-data/data/en/curated-1k";
+import { describe, expect, it } from "vitest";
+import type { TopicDefinition } from "./topics/types";
+import { deriveWordPool, frequencyTierForRank, isSuitableWord } from "./word-pool";
+
+function makeData(words: Record<string, string[]>): CuratedWordData {
+	return {
+		meta: {
+			version: "test",
+			tier: "test",
+			wordCount: Object.keys(words).length,
+			generatedAt: "",
+			license: "",
+			attribution: "",
+			sources: { wordfreq: "", cmudict: "" },
+		},
+		words,
+	};
+}
+
+function makeTopic(): TopicDefinition {
+	return {
+		id: "test-topic",
+		targetSounds: ["AX"],
+		isEligibleWord: (variants) =>
+			variants.every((v) => v.split(" ").some((t) => t.replace(/[012]$/, "") === "AX")),
+		slotSpec: [],
+		display: { kicker: "", heading: "", description: "", startLabel: "" },
+		lessonCatalog: [],
+	};
+}
+
+describe("isSuitableWord", () => {
+	it("accepts ordinary lowercase words of 3+ letters", () => {
+		expect(isSuitableWord("about")).toBe(true);
+		expect(isSuitableWord("cat")).toBe(true);
+		expect(isSuitableWord("elizabeth")).toBe(true);
+	});
+
+	it("rejects words with non-alphabetic characters", () => {
+		expect(isSuitableWord("don't")).toBe(false);
+		expect(isSuitableWord("o'clock")).toBe(false);
+		expect(isSuitableWord("mother-in-law")).toBe(false);
+	});
+
+	it("rejects words shorter than 3 letters", () => {
+		expect(isSuitableWord("a")).toBe(false);
+		expect(isSuitableWord("an")).toBe(false);
+	});
+
+	it("rejects blocklisted words", () => {
+		for (const blocked of ["etc", "bmw", "aaa", "le", "feb", "aug", "w"]) {
+			expect(isSuitableWord(blocked)).toBe(false);
+		}
+	});
+});
+
+describe("deriveWordPool", () => {
+	it("composes the shared suitability filter with the topic predicate", () => {
+		const data = makeData({
+			// eligible: suitable and every variant has AX
+			about: ["AX0 B AU1 T"],
+			// fails topic predicate: second variant has no AX
+			the: ["DH AX0", "DH AH1"],
+			// fails suitability (blocklist) even though the topic predicate passes
+			etc: ["EH1 T S EH2 T ER0 AX0"],
+			// fails suitability (too short)
+			ab: ["AX0 B"],
+		});
+		const pool = deriveWordPool(data, makeTopic());
+		expect(pool.map((w) => w.word)).toEqual(["about"]);
+	});
+
+	it("computes syllable count, target-sound count, and positions from the first variant", () => {
+		const data = makeData({
+			about: ["AX0 B AU1 T"],
+			banana: ["B AX0 N AE1 N AX0"],
+			believer: ["B I1 K AX0 T I1"],
+		});
+		const pool = deriveWordPool(data, makeTopic());
+		const byWord = new Map(pool.map((w) => [w.word, w]));
+
+		const about = byWord.get("about");
+		expect(about?.syllableCount).toBe(2);
+		expect(about?.targetSoundCount).toBe(1);
+		expect(about?.targetSoundPositions).toEqual(["initial"]);
+
+		const banana = byWord.get("banana");
+		expect(banana?.syllableCount).toBe(3);
+		expect(banana?.targetSoundCount).toBe(2);
+		expect(banana?.targetSoundPositions).toEqual(["initial", "final"]);
+
+		const believer = byWord.get("believer");
+		expect(believer?.syllableCount).toBe(3);
+		expect(believer?.targetSoundPositions).toEqual(["medial"]);
+	});
+
+	it("records frequency rank and tier from data order", () => {
+		const data = makeData({
+			about: ["AX0 B AU1 T"],
+			the: ["DH AH1"],
+			banana: ["B AX0 N AE1 N AX0"],
+		});
+		const pool = deriveWordPool(data, makeTopic());
+		const banana = pool.find((w) => w.word === "banana");
+		expect(banana?.rank).toBe(2);
+		expect(banana?.frequencyTier).toBe("top-1k");
+	});
+});
+
+describe("frequencyTierForRank", () => {
+	it("bands ranks into 1k / 5k / 10k tiers", () => {
+		expect(frequencyTierForRank(0)).toBe("top-1k");
+		expect(frequencyTierForRank(999)).toBe("top-1k");
+		expect(frequencyTierForRank(1000)).toBe("top-5k");
+		expect(frequencyTierForRank(4999)).toBe("top-5k");
+		expect(frequencyTierForRank(5000)).toBe("top-10k");
+	});
+});

--- a/apps/lab/src/lib/practice/word-pool.ts
+++ b/apps/lab/src/lib/practice/word-pool.ts
@@ -42,8 +42,8 @@ export function frequencyTierForRank(rank: number): FrequencyTier {
 	return "top-10k";
 }
 
-/** Syllable-band position of one target-sound occurrence within a word. */
-export type TargetSoundPosition = "initial" | "medial" | "final";
+/** Position of one topic-sound occurrence among a word's syllables. */
+export type TopicSoundPosition = "initial" | "medial" | "final";
 
 export interface PoolWord {
 	word: string;
@@ -54,18 +54,23 @@ export interface PoolWord {
 	frequencyTier: FrequencyTier;
 	/** Facets below are computed from the first CMU variant. */
 	syllableCount: number;
-	targetSoundCount: number;
-	/** One entry per target-sound occurrence, in order of appearance. */
-	targetSoundPositions: readonly TargetSoundPosition[];
+	topicSoundCount: number;
+	/** One entry per topic-sound occurrence, in order of appearance. */
+	topicSoundPositions: readonly TopicSoundPosition[];
 }
 
 /**
  * Derives the topic's word pool from tier-2 data: shared suitability filter,
- * then the topic's own predicate, then runtime facets against its target
+ * then the topic's own predicate, then runtime facets against its topic
  * sounds. Pure and synchronous; callers load the data via the tier-2 façade.
+ *
+ * Facets come from the first CMU variant (consistent with the reveal's
+ * "CMU's first listing"), and topic-sound occurrences are counted among
+ * vowel nuclei only — a topic teaching a consonant sound will need this
+ * extended before its facets mean anything.
  */
 export function deriveWordPool(data: CuratedWordData, topic: TopicDefinition): PoolWord[] {
-	const targetSounds = new Set<PhonemeSymbolId>(topic.targetSounds);
+	const topicSounds = new Set<PhonemeSymbolId>(topic.topicSounds);
 	const pool: PoolWord[] = [];
 
 	let rank = -1;
@@ -80,12 +85,12 @@ export function deriveWordPool(data: CuratedWordData, topic: TopicDefinition): P
 			if (baseId && getPhonemeCategory(baseId) === "vowel") nuclei.push(baseId);
 		}
 
-		const targetSoundPositions: TargetSoundPosition[] = [];
+		const topicSoundPositions: TopicSoundPosition[] = [];
 		nuclei.forEach((nucleus, index) => {
-			if (!targetSounds.has(nucleus)) return;
-			if (index === 0) targetSoundPositions.push("initial");
-			else if (index === nuclei.length - 1) targetSoundPositions.push("final");
-			else targetSoundPositions.push("medial");
+			if (!topicSounds.has(nucleus)) return;
+			if (index === 0) topicSoundPositions.push("initial");
+			else if (index === nuclei.length - 1) topicSoundPositions.push("final");
+			else topicSoundPositions.push("medial");
 		});
 
 		pool.push({
@@ -94,8 +99,8 @@ export function deriveWordPool(data: CuratedWordData, topic: TopicDefinition): P
 			rank,
 			frequencyTier: frequencyTierForRank(rank),
 			syllableCount: nuclei.length,
-			targetSoundCount: targetSoundPositions.length,
-			targetSoundPositions,
+			topicSoundCount: topicSoundPositions.length,
+			topicSoundPositions,
 		});
 	}
 

--- a/apps/lab/src/lib/practice/word-pool.ts
+++ b/apps/lab/src/lib/practice/word-pool.ts
@@ -1,0 +1,108 @@
+/**
+ * Practice word pool: derived at runtime from the tier-2 phoneme-lookup
+ * façade, never curated. The engine owns the shared word-suitability filter;
+ * topics contribute only their own eligibility predicate (#140).
+ */
+import {
+	getPhonemeCategory,
+	type PhonemeSymbolId,
+	tryExtractBasePhonemeId,
+} from "@phonaria/phonetics-data";
+import type { CuratedWordData } from "@phonaria/phonetics-data/data/en/curated-1k";
+import { loadTier2 } from "../phoneme-lookup/shared";
+import type { TopicDefinition } from "./topics/types";
+
+/**
+ * Editorial blocklist for words that read badly in play (abbreviations,
+ * initialisms, loanword fragments). Grows as bad words are spotted.
+ */
+export const EditorialBlocklist: ReadonlySet<string> = new Set([
+	"etc",
+	"bmw",
+	"aaa",
+	"le",
+	"feb",
+	"aug",
+	"w",
+]);
+
+/**
+ * Shared word-suitability filter inherited by every topic: alphabetic
+ * characters only, at least 3 letters, not blocklisted.
+ */
+export function isSuitableWord(word: string): boolean {
+	return /^[a-z]+$/.test(word) && word.length >= 3 && !EditorialBlocklist.has(word);
+}
+
+export type FrequencyTier = "top-1k" | "top-5k" | "top-10k";
+
+export function frequencyTierForRank(rank: number): FrequencyTier {
+	if (rank < 1_000) return "top-1k";
+	if (rank < 5_000) return "top-5k";
+	return "top-10k";
+}
+
+/** Syllable-band position of one target-sound occurrence within a word. */
+export type TargetSoundPosition = "initial" | "medial" | "final";
+
+export interface PoolWord {
+	word: string;
+	/** Raw CMU variants (phoneme IDs with stress digits), in CMU order. */
+	variants: readonly string[];
+	/** 0-based frequency rank in the tier-2 data (which is frequency-ordered). */
+	rank: number;
+	frequencyTier: FrequencyTier;
+	/** Facets below are computed from the first CMU variant. */
+	syllableCount: number;
+	targetSoundCount: number;
+	/** One entry per target-sound occurrence, in order of appearance. */
+	targetSoundPositions: readonly TargetSoundPosition[];
+}
+
+/**
+ * Derives the topic's word pool from tier-2 data: shared suitability filter,
+ * then the topic's own predicate, then runtime facets against its target
+ * sounds. Pure and synchronous; callers load the data via the tier-2 façade.
+ */
+export function deriveWordPool(data: CuratedWordData, topic: TopicDefinition): PoolWord[] {
+	const targetSounds = new Set<PhonemeSymbolId>(topic.targetSounds);
+	const pool: PoolWord[] = [];
+
+	let rank = -1;
+	for (const [word, variants] of Object.entries(data.words)) {
+		rank += 1;
+		if (!isSuitableWord(word) || !topic.isEligibleWord(variants)) continue;
+
+		// Vowel nuclei of the first variant: one per syllable, in order.
+		const nuclei: PhonemeSymbolId[] = [];
+		for (const token of variants[0].split(" ")) {
+			const baseId = tryExtractBasePhonemeId(token);
+			if (baseId && getPhonemeCategory(baseId) === "vowel") nuclei.push(baseId);
+		}
+
+		const targetSoundPositions: TargetSoundPosition[] = [];
+		nuclei.forEach((nucleus, index) => {
+			if (!targetSounds.has(nucleus)) return;
+			if (index === 0) targetSoundPositions.push("initial");
+			else if (index === nuclei.length - 1) targetSoundPositions.push("final");
+			else targetSoundPositions.push("medial");
+		});
+
+		pool.push({
+			word,
+			variants,
+			rank,
+			frequencyTier: frequencyTierForRank(rank),
+			syllableCount: nuclei.length,
+			targetSoundCount: targetSoundPositions.length,
+			targetSoundPositions,
+		});
+	}
+
+	return pool;
+}
+
+/** Loads tier-2 data through the phoneme-lookup façade and derives the pool. */
+export async function loadWordPoolForTopic(topic: TopicDefinition): Promise<PoolWord[]> {
+	return deriveWordPool(await loadTier2(), topic);
+}


### PR DESCRIPTION
Closes #142. Part of #140 (implementation steps 1–3).

## What this adds

Pure engine foundation for Practice, all Lab-local under `apps/lab/src/lib/practice/` with sibling node-env tests. No UI, no routes, no scoring — those are later steps of #140.

- **Word pool** (`word-pool.ts`): engine-owned shared word-suitability filter (alphabetic only, ≥3 letters, editorial blocklist seeded with `etc, bmw, aaa, le, feb, aug, w`) composed with the topic's own predicate over the tier-2 top-10k façade. Runtime facets per word: syllable count, topic-sound count and positions, frequency rank/tier. Facets come from the first CMU variant; occurrences are counted among vowel nuclei (documented limitation for future consonant topics).
- **Topic seam** (`topics/`): `TopicDefinition` type; `topics/schwa/` exports the eligibility predicate (every CMU variant contains `AX`), the five-slot spec, topic sounds, verbatim start-screen copy, and a stubbed lesson catalog. `topics/index.ts` is the only wiring point — a second topic needs one folder + one registry entry.
- **Session generator** (`session-generator.ts`): pure function of `(pool, slot spec, rng)` with injectable RNG. Five ordered slots banded 2 / 2–3 / 3 / 3–4 / 4+; topic-sound position/count act as soft variety tie-breakers (bounded redraws, never quotas); within-session dedupe; memoryless across sessions.

## Verification

- Pool over the shipped top-10k yields exactly **3,373** words (spec: ~3,373); the CI test pins that and asserts every syllable band stays >200 deep (session demand is ≤2 per band). Actual depths: 1129 / 2485 / 1356 / 2026 / 887.
- Generator is deterministic under a seeded RNG, never repeats a word in a session, and respects all five bands across 100 seeds.
- `bun run check-types`, `bun run lint`, and the full lab suite (119 tests) pass.
- Two-axis code review (standards vs spec) ran; findings addressed in the second commit — notably renaming "target sound" to the glossary's "topic sound" per CONTEXT.md.