### PR TITLE
Add practice session loop with store and UI scaffolding

### DIFF
--- a/apps/lab/src/app/practice/[topic]/page.tsx
+++ b/apps/lab/src/app/practice/[topic]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getTopic, listTopics } from "@/lib/practice/topics";
+import { PracticeExperience } from "../_components/practice-experience";
+
+interface PracticeTopicPageProps {
+	params: Promise<{ topic: string }>;
+}
+
+export function generateStaticParams() {
+	return listTopics().map((topic) => ({ topic: topic.id }));
+}
+
+export async function generateMetadata({ params }: PracticeTopicPageProps): Promise<Metadata> {
+	const { topic: slug } = await params;
+	const topic = getTopic(slug);
+	if (!topic) return { title: "Practice", robots: { index: false, follow: true } };
+
+	return {
+		title: `${topic.display.heading} — Practice`,
+		description: topic.display.description,
+		robots: { index: false, follow: true },
+	};
+}
+
+export default async function PracticeTopicPage({ params }: PracticeTopicPageProps) {
+	const { topic: slug } = await params;
+	if (!getTopic(slug)) notFound();
+
+	// A TopicDefinition carries predicate functions, so it cannot cross the
+	// server/client boundary — the client re-resolves it from the registry.
+	return <PracticeExperience topicId={slug} />;
+}

--- a/apps/lab/src/app/practice/[topic]/page.tsx
+++ b/apps/lab/src/app/practice/[topic]/page.tsx
@@ -27,7 +27,6 @@ export default async function PracticeTopicPage({ params }: PracticeTopicPagePro
 	const { topic: slug } = await params;
 	if (!getTopic(slug)) notFound();
 
-	// A TopicDefinition carries predicate functions, so it cannot cross the
-	// server/client boundary — the client re-resolves it from the registry.
+	// A TopicDefinition carries predicates, so it cannot cross to the client.
 	return <PracticeExperience topicId={slug} />;
 }

--- a/apps/lab/src/app/practice/_components/practice-experience.tsx
+++ b/apps/lab/src/app/practice/_components/practice-experience.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { getTopic } from "@/lib/practice/topics";
+import { usePracticeSessionStore } from "../_store/practice-session-store";
+import { SessionScaffold } from "./session-scaffold";
+import { StartScreen } from "./start-screen";
+
+/**
+ * Owns the whole in-place practice experience: start screen, live session and
+ * reveal all run on /practice/[topic] as client state. Leaving the route
+ * abandons the session — there is no resume, by design (#140).
+ */
+export function PracticeExperience({ topicId }: { topicId: string }) {
+	const phase = usePracticeSessionStore((state) => state.phase);
+	const poolStatus = usePracticeSessionStore((state) => state.poolStatus);
+	const prefetchPool = usePracticeSessionStore((state) => state.prefetchPool);
+	const startSession = usePracticeSessionStore((state) => state.startSession);
+	const abandon = usePracticeSessionStore((state) => state.abandon);
+
+	// The registry is the source of truth for slugs; the server route already
+	// rejected unknown ones with notFound().
+	const topic = getTopic(topicId);
+
+	useEffect(() => {
+		if (!topic) return;
+		// Prefetch on start-screen mount so Start is the only thing that waits.
+		void prefetchPool(topic);
+		return () => abandon();
+	}, [topic, prefetchPool, abandon]);
+
+	if (!topic) return null;
+
+	if (phase === "idle") {
+		return (
+			<StartScreen
+				topic={topic}
+				poolStatus={poolStatus}
+				onStart={() => startSession(topic)}
+				onRetry={() => void prefetchPool(topic)}
+			/>
+		);
+	}
+
+	return <SessionScaffold topic={topic} />;
+}

--- a/apps/lab/src/app/practice/_components/practice-experience.tsx
+++ b/apps/lab/src/app/practice/_components/practice-experience.tsx
@@ -13,6 +13,7 @@ import { StartScreen } from "./start-screen";
 export function PracticeExperience({ topicId }: { topicId: string }) {
 	const phase = usePracticeSessionStore((state) => state.phase);
 	const poolStatus = usePracticeSessionStore((state) => state.poolStatus);
+	const sessionError = usePracticeSessionStore((state) => state.sessionError);
 	const prefetchPool = usePracticeSessionStore((state) => state.prefetchPool);
 	const startSession = usePracticeSessionStore((state) => state.startSession);
 	const abandon = usePracticeSessionStore((state) => state.abandon);
@@ -34,8 +35,9 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 			<StartScreen
 				topic={topic}
 				poolStatus={poolStatus}
+				sessionError={sessionError}
 				onStart={() => startSession(topic)}
-				onRetry={() => void prefetchPool(topic)}
+				onRetryPool={() => void prefetchPool(topic)}
 			/>
 		);
 	}

--- a/apps/lab/src/app/practice/_components/practice-experience.tsx
+++ b/apps/lab/src/app/practice/_components/practice-experience.tsx
@@ -7,9 +7,8 @@ import { SessionScaffold } from "./session-scaffold";
 import { StartScreen } from "./start-screen";
 
 /**
- * Owns the whole in-place practice experience: start screen, live session and
- * reveal all run on /practice/[topic] as client state. Leaving the route
- * abandons the session — there is no resume, by design (#140).
+ * Start screen, live session and reveal all run in place on /practice/[topic]
+ * as client state. Leaving the route abandons the session — no resume (#140).
  */
 export function PracticeExperience({ topicId }: { topicId: string }) {
 	const phase = usePracticeSessionStore((state) => state.phase);
@@ -18,13 +17,12 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 	const startSession = usePracticeSessionStore((state) => state.startSession);
 	const abandon = usePracticeSessionStore((state) => state.abandon);
 
-	// The registry is the source of truth for slugs; the server route already
-	// rejected unknown ones with notFound().
+	// The server route already rejected unknown slugs with notFound().
 	const topic = getTopic(topicId);
 
 	useEffect(() => {
 		if (!topic) return;
-		// Prefetch on start-screen mount so Start is the only thing that waits.
+		// Prefetch on mount so Start is the only thing that waits.
 		void prefetchPool(topic);
 		return () => abandon();
 	}, [topic, prefetchPool, abandon]);

--- a/apps/lab/src/app/practice/_components/session-scaffold.tsx
+++ b/apps/lab/src/app/practice/_components/session-scaffold.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+/**
+ * Temporary scaffolding so the session loop is drivable end-to-end while the
+ * designed UI lands: the round builder (palette, search, chips) is #145 and
+ * the scoreboard reveal is #146. Everything here reads and drives the session
+ * store only — replacing it should require no store changes.
+ */
+import { PhonemeIpaMap, type PhonemeSymbolId } from "@phonaria/phonetics-data";
+import { Button } from "@phonaria/ui/components/button";
+import type { TopicDefinition } from "@/lib/practice/topics/types";
+import {
+	type PracticeRound,
+	selectBlankCount,
+	selectSoundAccuracy,
+	selectTopicSoundTally,
+	selectWordsCorrect,
+	usePracticeSessionStore,
+} from "../_store/practice-session-store";
+
+/**
+ * Sequences travel as plain phoneme-ID strings through the scorer, so display
+ * falls back to the raw ID rather than trusting the cast.
+ */
+function toIpa(sound: string): string {
+	return PhonemeIpaMap[sound as PhonemeSymbolId] ?? sound;
+}
+
+function RoundBuilder({ topic }: { topic: TopicDefinition }) {
+	const rounds = usePracticeSessionStore((state) => state.rounds);
+	const currentIndex = usePracticeSessionStore((state) => state.currentIndex);
+	const nextRound = usePracticeSessionStore((state) => state.nextRound);
+	const prevRound = usePracticeSessionStore((state) => state.prevRound);
+	const openCheck = usePracticeSessionStore((state) => state.openCheck);
+
+	const round = rounds[currentIndex];
+	if (!round) return null;
+
+	const isLastRound = currentIndex === rounds.length - 1;
+
+	return (
+		<div className="w-full max-w-md flex flex-col items-center gap-4 text-center">
+			<p className="text-sm text-muted-foreground font-display">
+				{topic.display.kicker} · {topic.display.heading}
+			</p>
+			<p className="text-sm text-muted-foreground">
+				Round {currentIndex + 1} of {rounds.length}
+			</p>
+			<h1 className="text-3xl sm:text-4xl font-bold tracking-tight font-display">
+				{round.word.word}
+			</h1>
+			<p className="text-sm text-muted-foreground">
+				{round.word.syllableCount} syllables · the sound palette arrives with the round builder
+			</p>
+			<div className="flex items-center gap-2">
+				<Button variant="outline" disabled={currentIndex === 0} onClick={prevRound}>
+					Back
+				</Button>
+				{isLastRound ? (
+					<Button onClick={openCheck}>Finish session</Button>
+				) : (
+					<Button variant="outline" onClick={nextRound}>
+						Next word
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function PreSubmitCheck() {
+	const rounds = usePracticeSessionStore((state) => state.rounds);
+	const keepEditing = usePracticeSessionStore((state) => state.keepEditing);
+	const editRound = usePracticeSessionStore((state) => state.editRound);
+	const submit = usePracticeSessionStore((state) => state.submit);
+
+	const blanks = selectBlankCount(rounds);
+
+	return (
+		<div className="w-full max-w-md flex flex-col gap-4">
+			<h1 className="text-xl font-bold tracking-tight font-display">Before you submit</h1>
+			<ul className="flex flex-col gap-2">
+				{rounds.map((round: PracticeRound, index: number) => (
+					<li
+						key={round.word.word}
+						className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+					>
+						<span className="text-sm font-medium">{round.word.word}</span>
+						<span className="text-sm text-muted-foreground">
+							{round.sequence.length === 0 ? "No answer" : round.sequence.map(toIpa).join(" ")}
+						</span>
+						<Button variant="ghost" size="sm" onClick={() => editRound(index)}>
+							{round.sequence.length === 0 ? "Answer it" : "Change"}
+						</Button>
+					</li>
+				))}
+			</ul>
+			<div className="flex items-center justify-end gap-2">
+				<Button variant="outline" onClick={keepEditing}>
+					Keep editing
+				</Button>
+				<Button onClick={submit}>
+					{blanks > 0 ? `Submit with ${blanks} blank${blanks === 1 ? "" : "s"}` : "Submit session"}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function Scoreboard({ topic, onNewSession }: { topic: TopicDefinition; onNewSession: () => void }) {
+	const rounds = usePracticeSessionStore((state) => state.rounds);
+	const scores = usePracticeSessionStore((state) => state.scores);
+	if (!scores) return null;
+
+	const accuracy = selectSoundAccuracy(scores);
+	const topicTally = selectTopicSoundTally(scores, topic.topicSounds);
+	const topicIpa = topic.topicSounds.map(toIpa).join(", ");
+
+	return (
+		<div className="w-full max-w-md flex flex-col items-center gap-4 text-center">
+			<h1 className="text-2xl sm:text-3xl font-bold tracking-tight font-display">
+				{selectWordsCorrect(scores)} of {scores.length} words correct
+			</h1>
+			<div className="flex items-center gap-6 text-sm text-muted-foreground">
+				<span>{accuracy === null ? "—" : `${Math.round(accuracy * 100)}%`} sound accuracy</span>
+				<span>
+					{topicTally.matched} of {topicTally.total} /{topicIpa}/ placed
+				</span>
+			</div>
+			<ul className="w-full flex flex-col gap-2 text-left">
+				{scores.map((score, index) => (
+					<li
+						key={rounds[index].word.word}
+						className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+					>
+						<span className="text-sm font-medium">{rounds[index].word.word}</span>
+						<span className="text-sm text-muted-foreground">
+							{score.reference.map(toIpa).join(" ")}
+						</span>
+						<span className="text-sm">{score.correct ? "Correct" : "Not yet"}</span>
+					</li>
+				))}
+			</ul>
+			<Button onClick={onNewSession}>New session</Button>
+		</div>
+	);
+}
+
+export function SessionScaffold({ topic }: { topic: TopicDefinition }) {
+	const phase = usePracticeSessionStore((state) => state.phase);
+	const abandon = usePracticeSessionStore((state) => state.abandon);
+	const startSession = usePracticeSessionStore((state) => state.startSession);
+
+	const onNewSession = () => {
+		abandon();
+		startSession(topic);
+	};
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in duration-500">
+			{phase === "building" ? <RoundBuilder topic={topic} /> : null}
+			{phase === "checking" ? <PreSubmitCheck /> : null}
+			{phase === "review" ? <Scoreboard topic={topic} onNewSession={onNewSession} /> : null}
+		</div>
+	);
+}

--- a/apps/lab/src/app/practice/_components/session-scaffold.tsx
+++ b/apps/lab/src/app/practice/_components/session-scaffold.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 /**
- * Temporary scaffolding so the session loop is drivable end-to-end while the
- * designed UI lands: the round builder (palette, search, chips) is #145 and
- * the scoreboard reveal is #146. Everything here reads and drives the session
- * store only — replacing it should require no store changes.
+ * Temporary scaffolding so the session loop is drivable while the designed UI
+ * lands — round builder is #145, scoreboard reveal is #146. Drives the store
+ * only, so replacing it should need no store changes.
  */
 import { PhonemeIpaMap, type PhonemeSymbolId } from "@phonaria/phonetics-data";
 import { Button } from "@phonaria/ui/components/button";
@@ -18,10 +17,7 @@ import {
 	usePracticeSessionStore,
 } from "../_store/practice-session-store";
 
-/**
- * Sequences travel as plain phoneme-ID strings through the scorer, so display
- * falls back to the raw ID rather than trusting the cast.
- */
+/** Sequences are plain strings through the scorer, so don't trust the cast. */
 function toIpa(sound: string): string {
 	return PhonemeIpaMap[sound as PhonemeSymbolId] ?? sound;
 }

--- a/apps/lab/src/app/practice/_components/session-scaffold.tsx
+++ b/apps/lab/src/app/practice/_components/session-scaffold.tsx
@@ -11,6 +11,7 @@ import type { TopicDefinition } from "@/lib/practice/topics/types";
 import {
 	type PracticeRound,
 	selectBlankCount,
+	selectReviewRows,
 	selectSoundAccuracy,
 	selectTopicSoundTally,
 	selectWordsCorrect,
@@ -66,6 +67,7 @@ function RoundBuilder({ topic }: { topic: TopicDefinition }) {
 
 function PreSubmitCheck() {
 	const rounds = usePracticeSessionStore((state) => state.rounds);
+	const sessionError = usePracticeSessionStore((state) => state.sessionError);
 	const keepEditing = usePracticeSessionStore((state) => state.keepEditing);
 	const editRound = usePracticeSessionStore((state) => state.editRound);
 	const submit = usePracticeSessionStore((state) => state.submit);
@@ -75,6 +77,11 @@ function PreSubmitCheck() {
 	return (
 		<div className="w-full max-w-md flex flex-col gap-4">
 			<h1 className="text-xl font-bold tracking-tight font-display">Before you submit</h1>
+			{sessionError ? (
+				<p role="alert" className="rounded-lg border border-border bg-muted p-3 text-sm">
+					{sessionError}
+				</p>
+			) : null}
 			<ul className="flex flex-col gap-2">
 				{rounds.map((round: PracticeRound, index: number) => (
 					<li
@@ -111,6 +118,7 @@ function Scoreboard({ topic, onNewSession }: { topic: TopicDefinition; onNewSess
 	const accuracy = selectSoundAccuracy(scores);
 	const topicTally = selectTopicSoundTally(scores, topic.topicSounds);
 	const topicIpa = topic.topicSounds.map(toIpa).join(", ");
+	const rows = selectReviewRows(rounds, scores);
 
 	return (
 		<div className="w-full max-w-md flex flex-col items-center gap-4 text-center">
@@ -124,12 +132,12 @@ function Scoreboard({ topic, onNewSession }: { topic: TopicDefinition; onNewSess
 				</span>
 			</div>
 			<ul className="w-full flex flex-col gap-2 text-left">
-				{scores.map((score, index) => (
+				{rows.map(({ round, score }) => (
 					<li
-						key={rounds[index].word.word}
+						key={round.word.word}
 						className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
 					>
-						<span className="text-sm font-medium">{rounds[index].word.word}</span>
+						<span className="text-sm font-medium">{round.word.word}</span>
 						<span className="text-sm text-muted-foreground">
 							{score.reference.map(toIpa).join(" ")}
 						</span>
@@ -144,13 +152,11 @@ function Scoreboard({ topic, onNewSession }: { topic: TopicDefinition; onNewSess
 
 export function SessionScaffold({ topic }: { topic: TopicDefinition }) {
 	const phase = usePracticeSessionStore((state) => state.phase);
-	const abandon = usePracticeSessionStore((state) => state.abandon);
 	const startSession = usePracticeSessionStore((state) => state.startSession);
 
-	const onNewSession = () => {
-		abandon();
-		startSession(topic);
-	};
+	// `startSession` already resets the session slice, so there is nothing to
+	// abandon first — and on failure it leaves the start screen showing why.
+	const onNewSession = () => startSession(topic);
 
 	return (
 		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in duration-500">

--- a/apps/lab/src/app/practice/_components/start-screen.tsx
+++ b/apps/lab/src/app/practice/_components/start-screen.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@phonaria/ui/components/button";
+import { Spinner } from "@phonaria/ui/components/spinner";
+import { RotateCcw } from "lucide-react";
+import type { TopicDefinition } from "@/lib/practice/topics/types";
+import type { PoolStatus } from "../_store/practice-session-store";
+
+interface StartScreenProps {
+	topic: TopicDefinition;
+	poolStatus: PoolStatus;
+	onStart: () => void;
+	onRetry: () => void;
+}
+
+/**
+ * Entry to a practice topic. Start is the sole loading gate — no skeletons —
+ * and a failed word-pool import blocks the experience with an inline retry
+ * rather than a dismissable toast (#140, #144).
+ */
+export function StartScreen({ topic, poolStatus, onStart, onRetry }: StartScreenProps) {
+	const isLoading = poolStatus === "idle" || poolStatus === "loading";
+	const hasFailed = poolStatus === "error";
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
+			<div className="w-full max-w-md flex flex-col items-center gap-4 text-center">
+				<p className="text-sm text-muted-foreground font-display">{topic.display.kicker}</p>
+				<h1 className="text-2xl sm:text-3xl font-bold tracking-tight font-display">
+					{topic.display.heading}
+				</h1>
+				<p className="text-sm text-muted-foreground text-pretty">{topic.display.description}</p>
+
+				{hasFailed ? (
+					<div
+						role="alert"
+						className="w-full flex flex-col items-center gap-3 rounded-lg border border-border bg-muted p-4"
+					>
+						<p className="text-sm text-foreground">
+							We couldn't load the words for this topic. Check your connection and try again.
+						</p>
+						<Button variant="outline" size="lg" onClick={onRetry}>
+							<RotateCcw />
+							Retry
+						</Button>
+					</div>
+				) : (
+					<Button size="lg" className="mt-2" disabled={isLoading} onClick={onStart}>
+						{isLoading ? <Spinner /> : null}
+						{topic.display.startLabel}
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/lab/src/app/practice/_components/start-screen.tsx
+++ b/apps/lab/src/app/practice/_components/start-screen.tsx
@@ -6,20 +6,35 @@ import { RotateCcw } from "lucide-react";
 import type { TopicDefinition } from "@/lib/practice/topics/types";
 import type { PoolStatus } from "../_store/practice-session-store";
 
+const POOL_LOAD_FAILED =
+	"We couldn't load the words for this topic. Check your connection and try again.";
+
 interface StartScreenProps {
 	topic: TopicDefinition;
 	poolStatus: PoolStatus;
+	/** Set when the pool loaded but the session failed to draw. */
+	sessionError: string | null;
 	onStart: () => void;
-	onRetry: () => void;
+	onRetryPool: () => void;
 }
 
 /**
- * Start is the sole loading gate — no skeletons — and a failed pool import
- * blocks with an inline retry rather than a dismissable toast (#140).
+ * Start is the sole loading gate — no skeletons — and a failure blocks with an
+ * inline retry rather than a dismissable toast (#140). A failed pool retries
+ * the load; a failed draw retries the draw.
  */
-export function StartScreen({ topic, poolStatus, onStart, onRetry }: StartScreenProps) {
+export function StartScreen({
+	topic,
+	poolStatus,
+	sessionError,
+	onStart,
+	onRetryPool,
+}: StartScreenProps) {
 	const isLoading = poolStatus === "idle" || poolStatus === "loading";
-	const hasFailed = poolStatus === "error";
+
+	let failure: { message: string; onRetry: () => void } | null = null;
+	if (poolStatus === "error") failure = { message: POOL_LOAD_FAILED, onRetry: onRetryPool };
+	else if (sessionError) failure = { message: sessionError, onRetry: onStart };
 
 	return (
 		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
@@ -30,23 +45,27 @@ export function StartScreen({ topic, poolStatus, onStart, onRetry }: StartScreen
 				</h1>
 				<p className="text-sm text-muted-foreground text-pretty">{topic.display.description}</p>
 
-				{hasFailed ? (
+				{failure ? (
 					<div
 						role="alert"
 						className="w-full flex flex-col items-center gap-3 rounded-lg border border-border bg-muted p-4"
 					>
-						<p className="text-sm text-foreground">
-							We couldn't load the words for this topic. Check your connection and try again.
-						</p>
-						<Button variant="outline" size="lg" onClick={onRetry}>
+						<p className="text-sm text-foreground">{failure.message}</p>
+						<Button variant="outline" size="lg" onClick={failure.onRetry}>
 							<RotateCcw />
 							Retry
 						</Button>
 					</div>
 				) : (
-					<Button size="lg" className="mt-2" disabled={isLoading} onClick={onStart}>
+					<Button
+						size="lg"
+						className="mt-2"
+						disabled={isLoading}
+						aria-busy={isLoading}
+						onClick={onStart}
+					>
 						{isLoading ? <Spinner /> : null}
-						{topic.display.startLabel}
+						{isLoading ? "Loading words…" : topic.display.startLabel}
 					</Button>
 				)}
 			</div>

--- a/apps/lab/src/app/practice/_components/start-screen.tsx
+++ b/apps/lab/src/app/practice/_components/start-screen.tsx
@@ -14,9 +14,8 @@ interface StartScreenProps {
 }
 
 /**
- * Entry to a practice topic. Start is the sole loading gate — no skeletons —
- * and a failed word-pool import blocks the experience with an inline retry
- * rather than a dismissable toast (#140, #144).
+ * Start is the sole loading gate — no skeletons — and a failed pool import
+ * blocks with an inline retry rather than a dismissable toast (#140).
  */
 export function StartScreen({ topic, poolStatus, onStart, onRetry }: StartScreenProps) {
 	const isLoading = poolStatus === "idle" || poolStatus === "loading";

--- a/apps/lab/src/app/practice/_store/practice-session-store.test.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
-import type { WordScore } from "@/lib/practice/scoring";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeVariant, type WordScore } from "@/lib/practice/scoring";
 import type { TopicDefinition } from "@/lib/practice/topics/types";
 import type { PoolWord } from "@/lib/practice/word-pool";
 import {
+	type PracticeRound,
 	selectBlankCount,
+	selectReviewRows,
 	selectSoundAccuracy,
 	selectTopicSoundTally,
 	selectWordsCorrect,
@@ -148,6 +150,51 @@ describe("practice session store — pool loading", () => {
 		expect(calls).toBe(1);
 		expect(usePracticeSessionStore.getState().poolStatus).toBe("ready");
 	});
+
+	it("drops a stale pool load that resolves after the topic changed", async () => {
+		let release: (words: PoolWord[]) => void = () => {};
+		const slowLoad = () =>
+			new Promise<PoolWord[]>((resolve) => {
+				release = resolve;
+			});
+
+		const pending = usePracticeSessionStore.getState().prefetchPool(testTopic, slowLoad);
+		await usePracticeSessionStore
+			.getState()
+			.prefetchPool({ ...testTopic, id: "other-topic" }, loadOk);
+		release(testPool);
+		await pending;
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.topicId).toBe("other-topic");
+		expect(state.poolStatus).toBe("ready");
+	});
+
+	/**
+	 * The stale guard keys on the load, not the topic: on A → B → A the first
+	 * load is stale even though `topicId` is back to A, so its late failure must
+	 * not clobber the pool the second load already delivered.
+	 */
+	it("drops a stale rejection that lands after the same topic reloaded", async () => {
+		let rejectFirst: (error: Error) => void = () => {};
+		const hangsThenFails = () =>
+			new Promise<PoolWord[]>((_, reject) => {
+				rejectFirst = reject;
+			});
+
+		const store = usePracticeSessionStore.getState();
+		const pending = store.prefetchPool(testTopic, hangsThenFails);
+		await store.prefetchPool({ ...testTopic, id: "other-topic" }, loadOk);
+		await store.prefetchPool(testTopic, loadOk);
+		expect(usePracticeSessionStore.getState().poolStatus).toBe("ready");
+
+		rejectFirst(new Error("late chunk failure"));
+		await pending;
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.poolStatus).toBe("ready");
+		expect(state.pool).toEqual(testPool);
+	});
 });
 
 describe("practice session store — starting a session", () => {
@@ -182,6 +229,38 @@ describe("practice session store — starting a session", () => {
 
 		expect(second).toEqual(first);
 	});
+
+	it("surfaces a draw failure instead of throwing into the click handler", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadOk);
+		// No pool word has 9 syllables, so the band runs dry and the generator throws.
+		usePracticeSessionStore
+			.getState()
+			.startSession({ ...testTopic, slotSpec: [{ min: 9, max: 9 }] }, seededRng(5));
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("idle");
+		expect(state.rounds).toEqual([]);
+		expect(state.sessionError).not.toBeNull();
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("clears a previous draw failure once a session starts", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadOk);
+		usePracticeSessionStore
+			.getState()
+			.startSession({ ...testTopic, slotSpec: [{ min: 9, max: 9 }] }, seededRng(5));
+		expect(usePracticeSessionStore.getState().sessionError).not.toBeNull();
+
+		usePracticeSessionStore.getState().startSession(testTopic, seededRng(7));
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("building");
+		expect(state.sessionError).toBeNull();
+		consoleError.mockRestore();
+	});
 });
 
 describe("practice session store — building rounds", () => {
@@ -212,6 +291,25 @@ describe("practice session store — building rounds", () => {
 		usePracticeSessionStore.getState().appendSound("S");
 		usePracticeSessionStore.getState().removeSoundAt(5);
 		expect(usePracticeSessionStore.getState().rounds[0].sequence).toEqual(["S"]);
+	});
+
+	it("publishes nothing for a no-op edit, so subscribers keep their rounds", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		const withSound = usePracticeSessionStore.getState().rounds;
+
+		// Out of range: nothing changes, so nothing is published.
+		usePracticeSessionStore.getState().removeSoundAt(5);
+		expect(usePracticeSessionStore.getState().rounds).toBe(withSound);
+
+		// A real clear does publish.
+		usePracticeSessionStore.getState().clearSequence();
+		const cleared = usePracticeSessionStore.getState().rounds;
+		expect(cleared).not.toBe(withSound);
+
+		// Clearing an already-empty sequence does not.
+		usePracticeSessionStore.getState().clearSequence();
+		expect(usePracticeSessionStore.getState().rounds).toBe(cleared);
 	});
 
 	it("clears the current sequence", async () => {
@@ -335,6 +433,43 @@ describe("practice session store — submit and review", () => {
 		expect(scores[0].correct).toBe(true);
 	});
 
+	it("keeps the answers in the check when scoring fails", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		// "QQ"/"ZZ" are not phoneme IDs, so `scoreWord` throws normalizing them.
+		const unscorable = makeWord("gibberish", ["QQ1 ZZ0"], 2, ["final"]);
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, async () => [unscorable]);
+		usePracticeSessionStore
+			.getState()
+			.startSession({ ...testTopic, slotSpec: [{ min: 2, max: 2 }] }, seededRng(3));
+
+		usePracticeSessionStore.getState().appendSound("S");
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("checking");
+		expect(state.scores).toBeNull();
+		expect(state.sessionError).not.toBeNull();
+		expect(state.rounds[0].sequence).toEqual(["S"]);
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("clears a scoring failure when the learner goes back to editing", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const unscorable = makeWord("gibberish", ["QQ1 ZZ0"], 2, ["final"]);
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, async () => [unscorable]);
+		usePracticeSessionStore
+			.getState()
+			.startSession({ ...testTopic, slotSpec: [{ min: 2, max: 2 }] }, seededRng(3));
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		usePracticeSessionStore.getState().keepEditing();
+		expect(usePracticeSessionStore.getState().sessionError).toBeNull();
+		consoleError.mockRestore();
+	});
+
 	it("makes submit irreversible — a second submit is a no-op", async () => {
 		await startTestSession();
 		usePracticeSessionStore.getState().openCheck();
@@ -408,25 +543,6 @@ describe("practice session store — abandoning", () => {
 		expect(state.phase).toBe("building");
 		expect(state.rounds.every((round) => round.sequence.length === 0)).toBe(true);
 	});
-
-	it("drops a stale pool load that resolves after the topic changed", async () => {
-		let release: (words: PoolWord[]) => void = () => {};
-		const slowLoad = () =>
-			new Promise<PoolWord[]>((resolve) => {
-				release = resolve;
-			});
-
-		const pending = usePracticeSessionStore.getState().prefetchPool(testTopic, slowLoad);
-		await usePracticeSessionStore
-			.getState()
-			.prefetchPool({ ...testTopic, id: "other-topic" }, loadOk);
-		release(testPool);
-		await pending;
-
-		const state = usePracticeSessionStore.getState();
-		expect(state.topicId).toBe("other-topic");
-		expect(state.poolStatus).toBe("ready");
-	});
 });
 
 describe("practice review selectors", () => {
@@ -439,11 +555,43 @@ describe("practice review selectors", () => {
 
 	it("counts words correct as the primary score", async () => {
 		await startTestSession();
+		// Answer only the first round correctly; the rest stay blank. Reading the
+		// answer off the drawn word keeps this independent of the seed.
+		const round = usePracticeSessionStore.getState().rounds[0];
+		for (const sound of normalizeVariant(round.word.variants[0])) {
+			usePracticeSessionStore.getState().appendSound(sound);
+		}
 		usePracticeSessionStore.getState().openCheck();
 		usePracticeSessionStore.getState().submit();
 
 		const scores = usePracticeSessionStore.getState().scores ?? [];
-		expect(selectWordsCorrect(scores)).toBe(0);
+		expect(scores[0].correct).toBe(true);
+		expect(selectWordsCorrect(scores)).toBe(1);
+	});
+
+	it("pairs each round with its score for review", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const { rounds, scores } = usePracticeSessionStore.getState();
+		const rows = selectReviewRows(rounds, scores);
+		expect(rows).toHaveLength(rounds.length);
+		expect(rows.map((row) => row.round.word.word)).toEqual(rounds.map((r) => r.word.word));
+		expect(rows[0].score).toBe(scores?.[0]);
+	});
+
+	it("returns no review rows before a submit", () => {
+		expect(selectReviewRows([], null)).toEqual([]);
+	});
+
+	it("drops rounds with no matching score rather than indexing past the end", () => {
+		const rounds = [
+			{ word: testPool[0], sequence: [] },
+			{ word: testPool[1], sequence: [] },
+		] satisfies PracticeRound[];
+		const scores = [{ correct: true } as WordScore];
+		expect(selectReviewRows(rounds, scores)).toHaveLength(1);
 	});
 
 	it("pools sound accuracy across the session rather than averaging per word", () => {

--- a/apps/lab/src/app/practice/_store/practice-session-store.test.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.test.ts
@@ -1,0 +1,480 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { WordScore } from "@/lib/practice/scoring";
+import type { TopicDefinition } from "@/lib/practice/topics/types";
+import type { PoolWord } from "@/lib/practice/word-pool";
+import {
+	selectBlankCount,
+	selectSoundAccuracy,
+	selectTopicSoundTally,
+	selectWordsCorrect,
+	usePracticeSessionStore,
+} from "./practice-session-store";
+
+/** Deterministic LCG so tests can assert exact reproducibility. */
+function seededRng(seed: number): () => number {
+	let state = seed >>> 0;
+	return () => {
+		state = (state * 1664525 + 1013904223) >>> 0;
+		return state / 2 ** 32;
+	};
+}
+
+function makeWord(
+	word: string,
+	variants: string[],
+	syllableCount: number,
+	topicSoundPositions: PoolWord["topicSoundPositions"],
+): PoolWord {
+	return {
+		word,
+		variants,
+		rank: 0,
+		frequencyTier: "top-1k",
+		syllableCount,
+		topicSoundCount: topicSoundPositions.length,
+		topicSoundPositions,
+	};
+}
+
+/**
+ * Enough depth for every schwa slot band (2, 2–3, 3, 3–4, 4+ syllables) to
+ * still have candidates after the earlier slots have drawn. Variants use
+ * Phonaria phoneme IDs with stress digits, as stored.
+ */
+const testPool: PoolWord[] = [
+	makeWord("sofa", ["S OU1 F AX0"], 2, ["final"]),
+	makeWord("above", ["AX0 B AH1 V"], 2, ["initial"]),
+	makeWord("banana", ["B AX0 N AE1 N AX0"], 3, ["initial", "final"]),
+	makeWord("celebrate", ["S E1 L AX0 B R EI2 T"], 3, ["medial"]),
+	makeWord("computer", ["K AX0 M P Y U1 T ER0"], 3, ["initial"]),
+	makeWord("america", ["AX0 M E1 R IX0 K AX0"], 4, ["initial", "final"]),
+	makeWord("comfortable", ["K AH1 M F ER0 T AX0 B AX0 L"], 4, ["medial", "final"]),
+	makeWord("aluminium", ["AE2 L Y AX0 M IX1 N I0 AX0 M"], 5, ["medial", "final"]),
+];
+
+const testTopic: TopicDefinition = {
+	id: "test-topic",
+	topicSounds: ["AX"],
+	isEligibleWord: () => true,
+	slotSpec: [
+		{ min: 2, max: 2 },
+		{ min: 2, max: 3 },
+		{ min: 3, max: 3 },
+		{ min: 3, max: 4 },
+		{ min: 4, max: null },
+	],
+	display: {
+		kicker: "Practice",
+		heading: "Test",
+		description: "Test topic.",
+		startLabel: "Start session",
+	},
+	lessonCatalog: [],
+};
+
+const loadOk = async () => testPool;
+const loadFails = async (): Promise<PoolWord[]> => {
+	throw new Error("chunk load failed");
+};
+
+/** Puts the store in a ready-to-play session with a deterministic draw. */
+async function startTestSession(): Promise<void> {
+	await usePracticeSessionStore.getState().prefetchPool(testTopic, loadOk);
+	usePracticeSessionStore.getState().startSession(testTopic, seededRng(7));
+}
+
+afterEach(() => {
+	usePracticeSessionStore.getState().reset();
+});
+
+describe("practice session store — pool loading", () => {
+	it("starts idle with no pool and no session", () => {
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("idle");
+		expect(state.poolStatus).toBe("idle");
+		expect(state.pool).toBeNull();
+		expect(state.rounds).toEqual([]);
+		expect(state.scores).toBeNull();
+	});
+
+	it("prefetches the pool and reports it ready", async () => {
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadOk);
+		const state = usePracticeSessionStore.getState();
+		expect(state.poolStatus).toBe("ready");
+		expect(state.pool).toEqual(testPool);
+		expect(state.topicId).toBe("test-topic");
+	});
+
+	it("reports error status when the pool import fails", async () => {
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadFails);
+		const state = usePracticeSessionStore.getState();
+		expect(state.poolStatus).toBe("error");
+		expect(state.pool).toBeNull();
+	});
+
+	it("recovers when a retry succeeds after a failed import", async () => {
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadFails);
+		expect(usePracticeSessionStore.getState().poolStatus).toBe("error");
+
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, loadOk);
+		expect(usePracticeSessionStore.getState().poolStatus).toBe("ready");
+		expect(usePracticeSessionStore.getState().pool).toEqual(testPool);
+	});
+
+	it("does not reload a pool that is already ready", async () => {
+		let calls = 0;
+		const counted = async () => {
+			calls += 1;
+			return testPool;
+		};
+
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, counted);
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, counted);
+		expect(calls).toBe(1);
+	});
+
+	it("shares one in-flight load between concurrent prefetches", async () => {
+		let calls = 0;
+		const counted = async () => {
+			calls += 1;
+			return testPool;
+		};
+
+		const store = usePracticeSessionStore.getState();
+		await Promise.all([
+			store.prefetchPool(testTopic, counted),
+			store.prefetchPool(testTopic, counted),
+		]);
+		expect(calls).toBe(1);
+		expect(usePracticeSessionStore.getState().poolStatus).toBe("ready");
+	});
+});
+
+describe("practice session store — starting a session", () => {
+	it("does not start while the pool is still unloaded", () => {
+		usePracticeSessionStore.getState().startSession(testTopic, seededRng(1));
+		expect(usePracticeSessionStore.getState().phase).toBe("idle");
+		expect(usePracticeSessionStore.getState().rounds).toEqual([]);
+	});
+
+	it("builds one blank round per slot on start", async () => {
+		await startTestSession();
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("building");
+		expect(state.rounds).toHaveLength(testTopic.slotSpec.length);
+		expect(state.rounds.every((round) => round.sequence.length === 0)).toBe(true);
+		expect(state.currentIndex).toBe(0);
+	});
+
+	it("never repeats a word within a session", async () => {
+		await startTestSession();
+		const words = usePracticeSessionStore.getState().rounds.map((round) => round.word.word);
+		expect(new Set(words).size).toBe(words.length);
+	});
+
+	it("is deterministic for a given rng seed", async () => {
+		await startTestSession();
+		const first = usePracticeSessionStore.getState().rounds.map((round) => round.word.word);
+
+		usePracticeSessionStore.getState().reset();
+		await startTestSession();
+		const second = usePracticeSessionStore.getState().rounds.map((round) => round.word.word);
+
+		expect(second).toEqual(first);
+	});
+});
+
+describe("practice session store — building rounds", () => {
+	it("appends sounds to the current round only", async () => {
+		await startTestSession();
+		const store = usePracticeSessionStore.getState();
+		store.appendSound("S");
+		store.appendSound("OU");
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.rounds[0].sequence).toEqual(["S", "OU"]);
+		expect(state.rounds[1].sequence).toEqual([]);
+	});
+
+	it("removes a sound by index", async () => {
+		await startTestSession();
+		const store = usePracticeSessionStore.getState();
+		store.appendSound("S");
+		store.appendSound("OU");
+		store.appendSound("F");
+		store.removeSoundAt(1);
+
+		expect(usePracticeSessionStore.getState().rounds[0].sequence).toEqual(["S", "F"]);
+	});
+
+	it("ignores a remove at an out-of-range index", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		usePracticeSessionStore.getState().removeSoundAt(5);
+		expect(usePracticeSessionStore.getState().rounds[0].sequence).toEqual(["S"]);
+	});
+
+	it("clears the current sequence", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		usePracticeSessionStore.getState().clearSequence();
+		expect(usePracticeSessionStore.getState().rounds[0].sequence).toEqual([]);
+	});
+
+	it("keeps each round's answer when navigating away and back", async () => {
+		await startTestSession();
+		const store = usePracticeSessionStore.getState();
+		store.appendSound("S");
+		store.nextRound();
+		store.appendSound("AX");
+		store.prevRound();
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.currentIndex).toBe(0);
+		expect(state.rounds[0].sequence).toEqual(["S"]);
+		expect(state.rounds[1].sequence).toEqual(["AX"]);
+	});
+
+	it("jumps to a round by index", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().goToRound(3);
+		expect(usePracticeSessionStore.getState().currentIndex).toBe(3);
+	});
+
+	it("ignores jumps outside the session", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().goToRound(99);
+		usePracticeSessionStore.getState().goToRound(-1);
+		expect(usePracticeSessionStore.getState().currentIndex).toBe(0);
+	});
+
+	it("clamps navigation at both ends", async () => {
+		await startTestSession();
+		const store = usePracticeSessionStore.getState();
+		store.prevRound();
+		expect(usePracticeSessionStore.getState().currentIndex).toBe(0);
+
+		for (let i = 0; i < 10; i++) store.nextRound();
+		expect(usePracticeSessionStore.getState().currentIndex).toBe(testTopic.slotSpec.length - 1);
+	});
+});
+
+describe("practice session store — pre-submit check", () => {
+	it("opens the check from building", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		expect(usePracticeSessionStore.getState().phase).toBe("checking");
+	});
+
+	it("returns to building on keep editing", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().keepEditing();
+		expect(usePracticeSessionStore.getState().phase).toBe("building");
+	});
+
+	it("jumps from the check straight to a round for editing", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().editRound(2);
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("building");
+		expect(state.currentIndex).toBe(2);
+	});
+
+	it("rejects sound edits while the check is open", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().appendSound("S");
+		expect(usePracticeSessionStore.getState().rounds[0].sequence).toEqual([]);
+	});
+});
+
+describe("practice session store — submit and review", () => {
+	it("does not submit directly from building", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().submit();
+		expect(usePracticeSessionStore.getState().phase).toBe("building");
+		expect(usePracticeSessionStore.getState().scores).toBeNull();
+	});
+
+	it("scores every round on submit", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("review");
+		expect(state.scores).toHaveLength(testTopic.slotSpec.length);
+	});
+
+	it("allows blanks and scores them zero without special-casing", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const scores = usePracticeSessionStore.getState().scores ?? [];
+		expect(scores.every((score) => score.correct === false)).toBe(true);
+		expect(scores.every((score) => score.matched === 0)).toBe(true);
+		expect(scores.every((score) => score.referenceLength > 0)).toBe(true);
+	});
+
+	it("marks a strictly-correct answer correct", async () => {
+		await usePracticeSessionStore.getState().prefetchPool(testTopic, async () => [testPool[0]]);
+		usePracticeSessionStore
+			.getState()
+			.startSession({ ...testTopic, slotSpec: [{ min: 2, max: 2 }] }, seededRng(3));
+
+		const store = usePracticeSessionStore.getState();
+		for (const sound of ["S", "OU", "F", "AX"]) store.appendSound(sound);
+		store.openCheck();
+		store.submit();
+
+		const scores = usePracticeSessionStore.getState().scores ?? [];
+		expect(scores[0].correct).toBe(true);
+	});
+
+	it("makes submit irreversible — a second submit is a no-op", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+		const firstScores = usePracticeSessionStore.getState().scores;
+
+		usePracticeSessionStore.getState().submit();
+		expect(usePracticeSessionStore.getState().scores).toBe(firstScores);
+		expect(usePracticeSessionStore.getState().phase).toBe("review");
+	});
+
+	it("freezes answers after submit", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const store = usePracticeSessionStore.getState();
+		store.appendSound("S");
+		store.removeSoundAt(0);
+		store.clearSequence();
+		store.goToRound(2);
+		store.keepEditing();
+		store.editRound(1);
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("review");
+		expect(state.rounds[0].sequence).toEqual([]);
+		expect(state.currentIndex).toBe(0);
+	});
+});
+
+describe("practice session store — abandoning", () => {
+	it("abandons the session back to the start screen", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		usePracticeSessionStore.getState().abandon();
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("idle");
+		expect(state.rounds).toEqual([]);
+		expect(state.scores).toBeNull();
+		expect(state.currentIndex).toBe(0);
+	});
+
+	it("keeps the loaded pool when abandoning, so returning does not refetch", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().abandon();
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.poolStatus).toBe("ready");
+		expect(state.pool).toEqual(testPool);
+	});
+
+	it("abandons from review too", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+		usePracticeSessionStore.getState().abandon();
+
+		expect(usePracticeSessionStore.getState().phase).toBe("idle");
+		expect(usePracticeSessionStore.getState().scores).toBeNull();
+	});
+
+	it("starts a fresh session after abandoning", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		usePracticeSessionStore.getState().abandon();
+		usePracticeSessionStore.getState().startSession(testTopic, seededRng(11));
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.phase).toBe("building");
+		expect(state.rounds.every((round) => round.sequence.length === 0)).toBe(true);
+	});
+
+	it("drops a stale pool load that resolves after the topic changed", async () => {
+		let release: (words: PoolWord[]) => void = () => {};
+		const slowLoad = () =>
+			new Promise<PoolWord[]>((resolve) => {
+				release = resolve;
+			});
+
+		const pending = usePracticeSessionStore.getState().prefetchPool(testTopic, slowLoad);
+		await usePracticeSessionStore
+			.getState()
+			.prefetchPool({ ...testTopic, id: "other-topic" }, loadOk);
+		release(testPool);
+		await pending;
+
+		const state = usePracticeSessionStore.getState();
+		expect(state.topicId).toBe("other-topic");
+		expect(state.poolStatus).toBe("ready");
+	});
+});
+
+describe("practice review selectors", () => {
+	it("counts blank rounds", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().appendSound("S");
+		const rounds = usePracticeSessionStore.getState().rounds;
+		expect(selectBlankCount(rounds)).toBe(4);
+	});
+
+	it("counts words correct as the primary score", async () => {
+		await startTestSession();
+		usePracticeSessionStore.getState().openCheck();
+		usePracticeSessionStore.getState().submit();
+
+		const scores = usePracticeSessionStore.getState().scores ?? [];
+		expect(selectWordsCorrect(scores)).toBe(0);
+	});
+
+	it("pools sound accuracy across the session rather than averaging per word", () => {
+		const scores = [
+			{ matched: 3, learnerLength: 4, referenceLength: 4 },
+			{ matched: 1, learnerLength: 2, referenceLength: 8 },
+		];
+		// Pooled: 4 matched over 12 reference sounds. A per-word average would
+		// give (0.75 + 0.125) / 2 = 0.4375 instead.
+		expect(selectSoundAccuracy(scores)).toBeCloseTo(4 / 12);
+	});
+
+	it("uses the longer of learner and reference length as each denominator", () => {
+		const scores = [{ matched: 2, learnerLength: 6, referenceLength: 3 }];
+		expect(selectSoundAccuracy(scores)).toBeCloseTo(2 / 6);
+	});
+
+	it("returns null sound accuracy when there is nothing to score", () => {
+		expect(selectSoundAccuracy([])).toBeNull();
+	});
+
+	it("sums the topic sound tally across the session", () => {
+		const scores: Pick<WordScore, "tallies">[] = [
+			{ tallies: { AX: { matched: 2, total: 3 }, IX: { matched: 1, total: 1 } } },
+			{ tallies: { AX: { matched: 2, total: 4 } } },
+		];
+		expect(selectTopicSoundTally(scores, ["AX"])).toEqual({ matched: 4, total: 7 });
+	});
+
+	it("ignores sounds outside the topic in the tally", () => {
+		const scores: Pick<WordScore, "tallies">[] = [{ tallies: { IX: { matched: 1, total: 1 } } }];
+		expect(selectTopicSoundTally(scores, ["AX"])).toEqual({ matched: 0, total: 0 });
+	});
+});

--- a/apps/lab/src/app/practice/_store/practice-session-store.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.ts
@@ -1,0 +1,260 @@
+/**
+ * The in-memory practice session loop: build → pre-submit check → submit →
+ * review. Everything lives in this store for the lifetime of the page —
+ * reload or Back abandons the session, by design (#140, #144).
+ *
+ * Dependencies (pool loader, rng) are injected as optional trailing arguments
+ * so the whole loop is testable without mocks, mirroring the engine's
+ * `generateSession(pool, slots, rng)` seam.
+ */
+import { create } from "zustand";
+import { scoreWord, type WordScore } from "@/lib/practice/scoring";
+import { generateSession, type SessionRng } from "@/lib/practice/session-generator";
+import type { TopicDefinition } from "@/lib/practice/topics/types";
+import { loadWordPoolForTopic, type PoolWord } from "@/lib/practice/word-pool";
+
+/** Where the learner is in the session loop. */
+export type PracticePhase = "idle" | "building" | "checking" | "review";
+
+/** Loading state of the topic's word pool, which gates Start. */
+export type PoolStatus = "idle" | "loading" | "ready" | "error";
+
+export interface PracticeRound {
+	word: PoolWord;
+	/** The learner's sound sequence in phoneme-ID space; empty means blank. */
+	sequence: string[];
+}
+
+export type PoolLoader = (topic: TopicDefinition) => Promise<PoolWord[]>;
+
+interface PracticeSessionStore {
+	topicId: string | null;
+	phase: PracticePhase;
+	poolStatus: PoolStatus;
+	pool: PoolWord[] | null;
+	rounds: PracticeRound[];
+	currentIndex: number;
+	/** Set once on submit; null until the session is revealed. */
+	scores: WordScore[] | null;
+
+	prefetchPool: (topic: TopicDefinition, loadPool?: PoolLoader) => Promise<void>;
+	startSession: (topic: TopicDefinition, rng?: SessionRng) => void;
+
+	appendSound: (sound: string) => void;
+	removeSoundAt: (index: number) => void;
+	clearSequence: () => void;
+
+	goToRound: (index: number) => void;
+	nextRound: () => void;
+	prevRound: () => void;
+
+	openCheck: () => void;
+	keepEditing: () => void;
+	editRound: (index: number) => void;
+	submit: () => void;
+
+	/** Drops the session but keeps the loaded pool, so returning is instant. */
+	abandon: () => void;
+	/** Full teardown, including the pool. */
+	reset: () => void;
+}
+
+const initialSessionState = {
+	phase: "idle",
+	rounds: [],
+	currentIndex: 0,
+	scores: null,
+} satisfies Pick<PracticeSessionStore, "phase" | "rounds" | "currentIndex" | "scores">;
+
+const initialState = {
+	...initialSessionState,
+	topicId: null,
+	poolStatus: "idle",
+	pool: null,
+} satisfies Omit<
+	PracticeSessionStore,
+	| "prefetchPool"
+	| "startSession"
+	| "appendSound"
+	| "removeSoundAt"
+	| "clearSequence"
+	| "goToRound"
+	| "nextRound"
+	| "prevRound"
+	| "openCheck"
+	| "keepEditing"
+	| "editRound"
+	| "submit"
+	| "abandon"
+	| "reset"
+>;
+
+/** Replaces the current round's sequence, if the session is editable. */
+function withCurrentSequence(
+	state: PracticeSessionStore,
+	next: (sequence: string[]) => string[],
+): Partial<PracticeSessionStore> | null {
+	if (state.phase !== "building") return null;
+	const round = state.rounds[state.currentIndex];
+	if (!round) return null;
+
+	const rounds = state.rounds.slice();
+	rounds[state.currentIndex] = { ...round, sequence: next(round.sequence) };
+	return { rounds };
+}
+
+export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) => ({
+	...initialState,
+
+	prefetchPool: async (topic, loadPool = loadWordPoolForTopic) => {
+		const { topicId, poolStatus } = get();
+		const isCurrentTopic = topicId === topic.id;
+		// Already loaded or in flight for this topic — nothing to do. An error
+		// status deliberately falls through, so Retry is just another prefetch.
+		if (isCurrentTopic && (poolStatus === "loading" || poolStatus === "ready")) return;
+
+		set({ topicId: topic.id, poolStatus: "loading", pool: null });
+
+		try {
+			const pool = await loadPool(topic);
+			// A newer topic took over while this was in flight — drop the result.
+			if (get().topicId !== topic.id) return;
+			set({ pool, poolStatus: "ready" });
+		} catch {
+			if (get().topicId !== topic.id) return;
+			set({ pool: null, poolStatus: "error" });
+		}
+	},
+
+	startSession: (topic, rng = Math.random) => {
+		const { pool, poolStatus } = get();
+		// Start is the sole loading gate: no pool, no session.
+		if (poolStatus !== "ready" || !pool) return;
+
+		const words = generateSession(pool, topic.slotSpec, rng);
+		set({
+			...initialSessionState,
+			phase: "building",
+			rounds: words.map((word) => ({ word, sequence: [] })),
+		});
+	},
+
+	appendSound: (sound) => {
+		const patch = withCurrentSequence(get(), (sequence) => [...sequence, sound]);
+		if (patch) set(patch);
+	},
+
+	removeSoundAt: (index) => {
+		const patch = withCurrentSequence(get(), (sequence) =>
+			index >= 0 && index < sequence.length
+				? sequence.filter((_, position) => position !== index)
+				: sequence,
+		);
+		if (patch) set(patch);
+	},
+
+	clearSequence: () => {
+		const patch = withCurrentSequence(get(), () => []);
+		if (patch) set(patch);
+	},
+
+	goToRound: (index) => {
+		const { phase, rounds } = get();
+		if (phase !== "building") return;
+		if (index < 0 || index >= rounds.length) return;
+		set({ currentIndex: index });
+	},
+
+	nextRound: () => {
+		const { phase, rounds, currentIndex } = get();
+		if (phase !== "building") return;
+		set({ currentIndex: Math.min(currentIndex + 1, rounds.length - 1) });
+	},
+
+	prevRound: () => {
+		const { phase, currentIndex } = get();
+		if (phase !== "building") return;
+		set({ currentIndex: Math.max(currentIndex - 1, 0) });
+	},
+
+	openCheck: () => {
+		if (get().phase !== "building") return;
+		set({ phase: "checking" });
+	},
+
+	keepEditing: () => {
+		if (get().phase !== "checking") return;
+		set({ phase: "building" });
+	},
+
+	editRound: (index) => {
+		const { phase, rounds } = get();
+		if (phase !== "checking") return;
+		if (index < 0 || index >= rounds.length) return;
+		set({ phase: "building", currentIndex: index });
+	},
+
+	submit: () => {
+		const { phase, rounds } = get();
+		// Submit is irreversible: it is reachable only from the pre-submit check,
+		// and review has no way back into building.
+		if (phase !== "checking") return;
+
+		const scores = rounds.map((round) => scoreWord(round.sequence, [...round.word.variants]));
+		set({ phase: "review", scores });
+	},
+
+	abandon: () => set({ ...initialSessionState }),
+
+	reset: () => set({ ...initialState }),
+}));
+
+/** Rounds the learner left empty — surfaced by the pre-submit check. */
+export function selectBlankCount(rounds: readonly PracticeRound[]): number {
+	return rounds.filter((round) => round.sequence.length === 0).length;
+}
+
+/** The primary score: whole words matched exactly against an accepted variant. */
+export function selectWordsCorrect(scores: readonly Pick<WordScore, "correct">[]): number {
+	return scores.filter((score) => score.correct).length;
+}
+
+type SoundAccuracyInput = Pick<WordScore, "matched" | "learnerLength" | "referenceLength">;
+
+/**
+ * Secondary score, pooled across the whole session rather than averaged per
+ * word — so a long word carries more weight than a short one, and skipping
+ * never beats attempting. Null when there is nothing to score.
+ */
+export function selectSoundAccuracy(scores: readonly SoundAccuracyInput[]): number | null {
+	const denominator = scores.reduce(
+		(total, score) => total + Math.max(score.learnerLength, score.referenceLength),
+		0,
+	);
+	if (denominator === 0) return null;
+
+	const matched = scores.reduce((total, score) => total + score.matched, 0);
+	return matched / denominator;
+}
+
+/**
+ * The topic figure ("4 of 7 schwas placed"). The scorer stays topic-blind and
+ * reports every sound; the topic decides which ones it teaches.
+ */
+export function selectTopicSoundTally(
+	scores: readonly Pick<WordScore, "tallies">[],
+	topicSounds: readonly string[],
+): { matched: number; total: number } {
+	return scores.reduce(
+		(running, score) => {
+			for (const sound of topicSounds) {
+				const tally = score.tallies[sound];
+				if (!tally) continue;
+				running.matched += tally.matched;
+				running.total += tally.total;
+			}
+			return running;
+		},
+		{ matched: 0, total: 0 },
+	);
+}

--- a/apps/lab/src/app/practice/_store/practice-session-store.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.ts
@@ -31,6 +31,12 @@ interface PracticeSessionState {
 	rounds: PracticeRound[];
 	currentIndex: number;
 	scores: WordScore[] | null;
+	/**
+	 * Learner-facing message for a session that failed to draw or score. Both
+	 * come from data shape, not the network, so they are separate from
+	 * `poolStatus: "error"` and retry a different thing.
+	 */
+	sessionError: string | null;
 }
 
 interface PracticeSessionActions {
@@ -62,7 +68,12 @@ const initialSessionState = {
 	rounds: [],
 	currentIndex: 0,
 	scores: null,
+	sessionError: null,
 } satisfies Partial<PracticeSessionState>;
+
+const SESSION_DRAW_FAILED = "We couldn't put a session together for this topic. Please try again.";
+const SESSION_SCORE_FAILED =
+	"We couldn't score this session. Your answers are still here — try submitting again.";
 
 const initialState = {
 	...initialSessionState,
@@ -79,10 +90,22 @@ function withCurrentSequence(
 	const round = state.rounds[state.currentIndex];
 	if (!round) return null;
 
+	// A no-op edit returns the same array, so nothing is published and every
+	// `rounds` subscriber keeps its referential equality.
+	const sequence = next(round.sequence);
+	if (sequence === round.sequence) return null;
+
 	const rounds = state.rounds.slice();
-	rounds[state.currentIndex] = { ...round, sequence: next(round.sequence) };
+	rounds[state.currentIndex] = { ...round, sequence };
 	return { rounds };
 }
+
+/**
+ * Monotonic id for the in-flight pool load. `topicId` alone cannot tell a
+ * stale load from the live one when the same topic is requested again
+ * (A → B → A), so a late failure could otherwise clobber a ready pool.
+ */
+let activeLoad = 0;
 
 export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) => ({
 	...initialState,
@@ -93,15 +116,16 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 		// An error status falls through, so Retry is just another prefetch.
 		if (isCurrentTopic && (poolStatus === "loading" || poolStatus === "ready")) return;
 
+		const token = ++activeLoad;
 		set({ topicId: topic.id, poolStatus: "loading", pool: null });
 
 		try {
 			const pool = await loadPool(topic);
-			// A newer topic took over mid-flight — drop the stale result.
-			if (get().topicId !== topic.id) return;
+			// A newer load took over mid-flight — drop the stale result.
+			if (activeLoad !== token) return;
 			set({ pool, poolStatus: "ready" });
 		} catch {
-			if (get().topicId !== topic.id) return;
+			if (activeLoad !== token) return;
 			set({ pool: null, poolStatus: "error" });
 		}
 	},
@@ -111,7 +135,18 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 		// Start is the sole loading gate: no pool, no session.
 		if (poolStatus !== "ready" || !pool) return;
 
-		const words = generateSession(pool, topic.slotSpec, rng);
+		// `generateSession` throws when a band runs dry. That is a data-shape
+		// failure (the band-depth test guards it in CI), but it must not escape
+		// into a click handler — there is no route error boundary to catch it.
+		let words: PoolWord[];
+		try {
+			words = generateSession(pool, topic.slotSpec, rng);
+		} catch (error) {
+			console.error("practice: session generation failed", error);
+			set({ ...initialSessionState, sessionError: SESSION_DRAW_FAILED });
+			return;
+		}
+
 		set({
 			...initialSessionState,
 			phase: "building",
@@ -134,7 +169,7 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 	},
 
 	clearSequence: () => {
-		const patch = withCurrentSequence(get(), () => []);
+		const patch = withCurrentSequence(get(), (sequence) => (sequence.length === 0 ? sequence : []));
 		if (patch) set(patch);
 	},
 
@@ -164,14 +199,14 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 
 	keepEditing: () => {
 		if (get().phase !== "checking") return;
-		set({ phase: "building" });
+		set({ phase: "building", sessionError: null });
 	},
 
 	editRound: (index) => {
 		const { phase, rounds } = get();
 		if (phase !== "checking") return;
 		if (index < 0 || index >= rounds.length) return;
-		set({ phase: "building", currentIndex: index });
+		set({ phase: "building", currentIndex: index, sessionError: null });
 	},
 
 	submit: () => {
@@ -179,13 +214,27 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 		// Irreversible: reachable only from the check, and review has no way back.
 		if (phase !== "checking") return;
 
-		const scores = rounds.map((round) => scoreWord(round.sequence, [...round.word.variants]));
-		set({ phase: "review", scores });
+		// `scoreWord` throws on a pronunciation it cannot normalize. Staying in
+		// the check keeps the learner's answers rather than losing the session.
+		let scores: WordScore[];
+		try {
+			scores = rounds.map((round) => scoreWord(round.sequence, [...round.word.variants]));
+		} catch (error) {
+			console.error("practice: scoring failed", error);
+			set({ sessionError: SESSION_SCORE_FAILED });
+			return;
+		}
+
+		set({ phase: "review", scores, sessionError: null });
 	},
 
 	abandon: () => set({ ...initialSessionState }),
 
-	reset: () => set({ ...initialState }),
+	reset: () => {
+		// Any in-flight load belongs to the session being torn down.
+		activeLoad += 1;
+		set({ ...initialState });
+	},
 }));
 
 export function selectBlankCount(rounds: readonly PracticeRound[]): number {
@@ -194,6 +243,27 @@ export function selectBlankCount(rounds: readonly PracticeRound[]): number {
 
 export function selectWordsCorrect(scores: readonly Pick<WordScore, "correct">[]): number {
 	return scores.filter((score) => score.correct).length;
+}
+
+export interface ReviewRow {
+	round: PracticeRound;
+	score: WordScore;
+}
+
+/**
+ * Pairs each round with its score. `submit` builds the two arrays together, so
+ * this zip is total in practice — it exists so the review UI never indexes one
+ * array by the other's position.
+ */
+export function selectReviewRows(
+	rounds: readonly PracticeRound[],
+	scores: readonly WordScore[] | null,
+): ReviewRow[] {
+	if (!scores) return [];
+	return rounds.flatMap((round, index) => {
+		const score = scores[index];
+		return score ? [{ round, score }] : [];
+	});
 }
 
 type SoundAccuracyInput = Pick<WordScore, "matched" | "learnerLength" | "referenceLength">;

--- a/apps/lab/src/app/practice/_store/practice-session-store.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.ts
@@ -1,11 +1,9 @@
 /**
  * The in-memory practice session loop: build → pre-submit check → submit →
- * review. Everything lives in this store for the lifetime of the page —
- * reload or Back abandons the session, by design (#140, #144).
+ * review. Reload or Back abandons the session, by design (#140).
  *
- * Dependencies (pool loader, rng) are injected as optional trailing arguments
- * so the whole loop is testable without mocks, mirroring the engine's
- * `generateSession(pool, slots, rng)` seam.
+ * The pool loader and rng are optional trailing arguments so the loop is
+ * testable without mocks, mirroring `generateSession(pool, slots, rng)`.
  */
 import { create } from "zustand";
 import { scoreWord, type WordScore } from "@/lib/practice/scoring";
@@ -13,30 +11,29 @@ import { generateSession, type SessionRng } from "@/lib/practice/session-generat
 import type { TopicDefinition } from "@/lib/practice/topics/types";
 import { loadWordPoolForTopic, type PoolWord } from "@/lib/practice/word-pool";
 
-/** Where the learner is in the session loop. */
 export type PracticePhase = "idle" | "building" | "checking" | "review";
 
-/** Loading state of the topic's word pool, which gates Start. */
 export type PoolStatus = "idle" | "loading" | "ready" | "error";
 
 export interface PracticeRound {
 	word: PoolWord;
-	/** The learner's sound sequence in phoneme-ID space; empty means blank. */
+	/** Phoneme IDs; empty means the learner left the word blank. */
 	sequence: string[];
 }
 
 export type PoolLoader = (topic: TopicDefinition) => Promise<PoolWord[]>;
 
-interface PracticeSessionStore {
+interface PracticeSessionState {
 	topicId: string | null;
 	phase: PracticePhase;
 	poolStatus: PoolStatus;
 	pool: PoolWord[] | null;
 	rounds: PracticeRound[];
 	currentIndex: number;
-	/** Set once on submit; null until the session is revealed. */
 	scores: WordScore[] | null;
+}
 
+interface PracticeSessionActions {
 	prefetchPool: (topic: TopicDefinition, loadPool?: PoolLoader) => Promise<void>;
 	startSession: (topic: TopicDefinition, rng?: SessionRng) => void;
 
@@ -53,43 +50,27 @@ interface PracticeSessionStore {
 	editRound: (index: number) => void;
 	submit: () => void;
 
-	/** Drops the session but keeps the loaded pool, so returning is instant. */
+	/** Drops the session but keeps the pool; `reset` also drops the pool. */
 	abandon: () => void;
-	/** Full teardown, including the pool. */
 	reset: () => void;
 }
+
+type PracticeSessionStore = PracticeSessionState & PracticeSessionActions;
 
 const initialSessionState = {
 	phase: "idle",
 	rounds: [],
 	currentIndex: 0,
 	scores: null,
-} satisfies Pick<PracticeSessionStore, "phase" | "rounds" | "currentIndex" | "scores">;
+} satisfies Partial<PracticeSessionState>;
 
 const initialState = {
 	...initialSessionState,
 	topicId: null,
 	poolStatus: "idle",
 	pool: null,
-} satisfies Omit<
-	PracticeSessionStore,
-	| "prefetchPool"
-	| "startSession"
-	| "appendSound"
-	| "removeSoundAt"
-	| "clearSequence"
-	| "goToRound"
-	| "nextRound"
-	| "prevRound"
-	| "openCheck"
-	| "keepEditing"
-	| "editRound"
-	| "submit"
-	| "abandon"
-	| "reset"
->;
+} satisfies PracticeSessionState;
 
-/** Replaces the current round's sequence, if the session is editable. */
 function withCurrentSequence(
 	state: PracticeSessionStore,
 	next: (sequence: string[]) => string[],
@@ -109,15 +90,14 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 	prefetchPool: async (topic, loadPool = loadWordPoolForTopic) => {
 		const { topicId, poolStatus } = get();
 		const isCurrentTopic = topicId === topic.id;
-		// Already loaded or in flight for this topic — nothing to do. An error
-		// status deliberately falls through, so Retry is just another prefetch.
+		// An error status falls through, so Retry is just another prefetch.
 		if (isCurrentTopic && (poolStatus === "loading" || poolStatus === "ready")) return;
 
 		set({ topicId: topic.id, poolStatus: "loading", pool: null });
 
 		try {
 			const pool = await loadPool(topic);
-			// A newer topic took over while this was in flight — drop the result.
+			// A newer topic took over mid-flight — drop the stale result.
 			if (get().topicId !== topic.id) return;
 			set({ pool, poolStatus: "ready" });
 		} catch {
@@ -196,8 +176,7 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 
 	submit: () => {
 		const { phase, rounds } = get();
-		// Submit is irreversible: it is reachable only from the pre-submit check,
-		// and review has no way back into building.
+		// Irreversible: reachable only from the check, and review has no way back.
 		if (phase !== "checking") return;
 
 		const scores = rounds.map((round) => scoreWord(round.sequence, [...round.word.variants]));
@@ -209,12 +188,10 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 	reset: () => set({ ...initialState }),
 }));
 
-/** Rounds the learner left empty — surfaced by the pre-submit check. */
 export function selectBlankCount(rounds: readonly PracticeRound[]): number {
 	return rounds.filter((round) => round.sequence.length === 0).length;
 }
 
-/** The primary score: whole words matched exactly against an accepted variant. */
 export function selectWordsCorrect(scores: readonly Pick<WordScore, "correct">[]): number {
 	return scores.filter((score) => score.correct).length;
 }
@@ -222,9 +199,8 @@ export function selectWordsCorrect(scores: readonly Pick<WordScore, "correct">[]
 type SoundAccuracyInput = Pick<WordScore, "matched" | "learnerLength" | "referenceLength">;
 
 /**
- * Secondary score, pooled across the whole session rather than averaged per
- * word — so a long word carries more weight than a short one, and skipping
- * never beats attempting. Null when there is nothing to score.
+ * Pooled across the session, never averaged per word — so skipping never
+ * beats attempting. Null when there is nothing to score.
  */
 export function selectSoundAccuracy(scores: readonly SoundAccuracyInput[]): number | null {
 	const denominator = scores.reduce(
@@ -237,10 +213,7 @@ export function selectSoundAccuracy(scores: readonly SoundAccuracyInput[]): numb
 	return matched / denominator;
 }
 
-/**
- * The topic figure ("4 of 7 schwas placed"). The scorer stays topic-blind and
- * reports every sound; the topic decides which ones it teaches.
- */
+/** Filters the topic-blind scorer's per-sound counts down to what it teaches. */
 export function selectTopicSoundTally(
 	scores: readonly Pick<WordScore, "tallies">[],
 	topicSounds: readonly string[],

--- a/apps/lab/src/app/practice/error.tsx
+++ b/apps/lab/src/app/practice/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@phonaria/ui/components/button";
+import { RotateCcw } from "lucide-react";
+import { useEffect } from "react";
+
+/**
+ * Last resort for the Practice route. The store already catches the two known
+ * throws (session draw, scoring), so reaching this means something unforeseen
+ * broke — `reset` remounts the route, which starts a fresh session.
+ */
+export default function PracticeError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		console.error("practice: unhandled route error", error);
+	}, [error]);
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6">
+			<div
+				role="alert"
+				className="w-full max-w-md flex flex-col items-center gap-4 rounded-lg border border-border bg-muted p-6 text-center"
+			>
+				<h1 className="text-xl font-bold tracking-tight font-display">Practice hit a snag</h1>
+				<p className="text-sm text-muted-foreground text-pretty">
+					Something went wrong and the session was lost. Starting over should fix it.
+				</p>
+				<Button variant="outline" size="lg" onClick={reset}>
+					<RotateCcw />
+					Start over
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/lab/src/app/practice/page.tsx
+++ b/apps/lab/src/app/practice/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+import { listTopics } from "@/lib/practice/topics";
+
+/**
+ * Practice has one topic today, so /practice lands on the first registered
+ * one. The slug comes from the registry, not a literal, so adding topic #2
+ * needs no change here (#140).
+ */
+export default function PracticePage() {
+	redirect(`/practice/${listTopics()[0].id}`);
+}

--- a/apps/lab/src/app/practice/page.tsx
+++ b/apps/lab/src/app/practice/page.tsx
@@ -1,11 +1,7 @@
 import { redirect } from "next/navigation";
 import { listTopics } from "@/lib/practice/topics";
 
-/**
- * Practice has one topic today, so /practice lands on the first registered
- * one. The slug comes from the registry, not a literal, so adding topic #2
- * needs no change here (#140).
- */
+/** Slug comes from the registry, so adding topic #2 needs no change here. */
 export default function PracticePage() {
 	redirect(`/practice/${listTopics()[0].id}`);
 }

--- a/apps/lab/src/components/header.tsx
+++ b/apps/lab/src/components/header.tsx
@@ -33,6 +33,9 @@ export function Header() {
 				<Link href="/" className={navLinkClass}>
 					Transcription
 				</Link>
+				<Link href="/practice" className={navLinkClass}>
+					Practice
+				</Link>
 				<NavigationMenu>
 					<NavigationMenuList>
 						<NavigationMenuItem>

--- a/apps/lab/src/lib/phoneme-lookup/shared.ts
+++ b/apps/lab/src/lib/phoneme-lookup/shared.ts
@@ -8,10 +8,7 @@ import { createRetryableLoader } from "../retryable-loader";
 
 export { tokenizeText } from "../g2p/text-processing";
 
-/**
- * Tier 2 is a lazy chunk: fetched at most once, shared by concurrent callers,
- * and retryable after a failed load so callers can offer a working Retry.
- */
+/** Lazy chunk: fetched at most once, and retryable after a failed load. */
 export const loadTier2: () => Promise<CuratedWordData> = createRetryableLoader(() =>
 	import("@phonaria/phonetics-data/data/en/curated-10k").then(
 		(module) => module.EnglishCuratedTop10k,

--- a/apps/lab/src/lib/phoneme-lookup/shared.ts
+++ b/apps/lab/src/lib/phoneme-lookup/shared.ts
@@ -4,19 +4,19 @@ import {
 } from "@phonaria/phonetics-data/data/en/curated-1k";
 import type { G2PSyllable } from "../g2p/model";
 import { syllabify } from "../g2p/syllabifier";
+import { createRetryableLoader } from "../retryable-loader";
 
 export { tokenizeText } from "../g2p/text-processing";
 
-let tier2Promise: Promise<CuratedWordData> | null = null;
-
-export function loadTier2(): Promise<CuratedWordData> {
-	if (!tier2Promise) {
-		tier2Promise = import("@phonaria/phonetics-data/data/en/curated-10k").then(
-			(module) => module.EnglishCuratedTop10k,
-		);
-	}
-	return tier2Promise;
-}
+/**
+ * Tier 2 is a lazy chunk: fetched at most once, shared by concurrent callers,
+ * and retryable after a failed load so callers can offer a working Retry.
+ */
+export const loadTier2: () => Promise<CuratedWordData> = createRetryableLoader(() =>
+	import("@phonaria/phonetics-data/data/en/curated-10k").then(
+		(module) => module.EnglishCuratedTop10k,
+	),
+);
 
 export function cmuToSyllables(cmuVariant: string): G2PSyllable[] {
 	const tokens = cmuVariant.split(" ").filter((t) => t.length > 0);

--- a/apps/lab/src/lib/retryable-loader.test.ts
+++ b/apps/lab/src/lib/retryable-loader.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { createRetryableLoader } from "./retryable-loader";
+
+describe("createRetryableLoader", () => {
+	it("loads once and memoizes the result", async () => {
+		let calls = 0;
+		const load = createRetryableLoader(async () => {
+			calls += 1;
+			return "data";
+		});
+
+		expect(await load()).toBe("data");
+		expect(await load()).toBe("data");
+		expect(calls).toBe(1);
+	});
+
+	it("shares one in-flight request between concurrent callers", async () => {
+		let calls = 0;
+		let release: (value: string) => void = () => {};
+		const load = createRetryableLoader(() => {
+			calls += 1;
+			return new Promise<string>((resolve) => {
+				release = resolve;
+			});
+		});
+
+		const first = load();
+		const second = load();
+		release("data");
+
+		expect(await first).toBe("data");
+		expect(await second).toBe("data");
+		expect(calls).toBe(1);
+	});
+
+	it("rejects with the underlying failure", async () => {
+		const load = createRetryableLoader(async () => {
+			throw new Error("chunk load failed");
+		});
+
+		await expect(load()).rejects.toThrow(/chunk load failed/);
+	});
+
+	it("does not cache a rejection, so a later call can succeed", async () => {
+		let calls = 0;
+		const load = createRetryableLoader(async () => {
+			calls += 1;
+			if (calls === 1) throw new Error("chunk load failed");
+			return "data";
+		});
+
+		await expect(load()).rejects.toThrow(/chunk load failed/);
+		expect(await load()).toBe("data");
+		expect(calls).toBe(2);
+	});
+
+	it("retries again after a repeated failure", async () => {
+		let calls = 0;
+		const load = createRetryableLoader(async () => {
+			calls += 1;
+			throw new Error(`attempt ${calls}`);
+		});
+
+		await expect(load()).rejects.toThrow(/attempt 1/);
+		await expect(load()).rejects.toThrow(/attempt 2/);
+		await expect(load()).rejects.toThrow(/attempt 3/);
+	});
+});

--- a/apps/lab/src/lib/retryable-loader.test.ts
+++ b/apps/lab/src/lib/retryable-loader.test.ts
@@ -54,6 +54,19 @@ describe("createRetryableLoader", () => {
 		expect(calls).toBe(2);
 	});
 
+	it("turns a synchronous throw into a rejection and stays retryable", async () => {
+		let calls = 0;
+		const load = createRetryableLoader<string>(() => {
+			calls += 1;
+			if (calls === 1) throw new Error("sync boom");
+			return Promise.resolve("data");
+		});
+
+		await expect(load()).rejects.toThrow(/sync boom/);
+		expect(await load()).toBe("data");
+		expect(calls).toBe(2);
+	});
+
 	it("retries again after a repeated failure", async () => {
 		let calls = 0;
 		const load = createRetryableLoader(async () => {

--- a/apps/lab/src/lib/retryable-loader.ts
+++ b/apps/lab/src/lib/retryable-loader.ts
@@ -1,8 +1,7 @@
 /**
- * Memoizes an async load so concurrent callers share one request, while
- * leaving failures retryable: a rejection clears the cache instead of being
- * remembered forever. Caching a rejected promise would make any "Retry"
- * affordance a no-op for the rest of the tab's life (#144).
+ * Memoizes an async load so concurrent callers share one request, but clears
+ * the cache on rejection — remembering a failure would make any Retry a no-op
+ * for the rest of the tab's life.
  */
 export function createRetryableLoader<T>(load: () => Promise<T>): () => Promise<T> {
 	let pending: Promise<T> | null = null;

--- a/apps/lab/src/lib/retryable-loader.ts
+++ b/apps/lab/src/lib/retryable-loader.ts
@@ -1,0 +1,19 @@
+/**
+ * Memoizes an async load so concurrent callers share one request, while
+ * leaving failures retryable: a rejection clears the cache instead of being
+ * remembered forever. Caching a rejected promise would make any "Retry"
+ * affordance a no-op for the rest of the tab's life (#144).
+ */
+export function createRetryableLoader<T>(load: () => Promise<T>): () => Promise<T> {
+	let pending: Promise<T> | null = null;
+
+	return () => {
+		if (!pending) {
+			pending = load().catch((error: unknown) => {
+				pending = null;
+				throw error;
+			});
+		}
+		return pending;
+	};
+}

--- a/apps/lab/src/lib/retryable-loader.ts
+++ b/apps/lab/src/lib/retryable-loader.ts
@@ -8,7 +8,10 @@ export function createRetryableLoader<T>(load: () => Promise<T>): () => Promise<
 
 	return () => {
 		if (!pending) {
-			pending = load().catch((error: unknown) => {
+			// The wrapper calls `load` synchronously, so concurrent callers still
+			// share one in-flight request, but a synchronous throw surfaces as a
+			// rejection instead of escaping past the memo.
+			pending = (async () => load())().catch((error: unknown) => {
 				pending = null;
 				throw error;
 			});


### PR DESCRIPTION
## Summary

Implements the core practice session loop (build → check → submit → review) with a Zustand store managing state transitions, word pool loading, and scoring. Includes temporary UI scaffolding to drive the session while designed components land.

## Key Changes

- **Practice session store** (`practice-session-store.ts`): Manages the full session lifecycle with phases (idle, building, checking, review), round sequencing, sound input, and submission/scoring. Includes pool prefetching with retry support and deterministic session generation via seeded RNG.

- **Comprehensive store tests** (`practice-session-store.test.ts`): 480 lines of tests covering pool loading, session initialization, round navigation, sound editing, pre-submit checks, submission, scoring, and abandonment. Uses deterministic seeded RNG for reproducible test assertions.

- **Retryable loader utility** (`retryable-loader.ts`): Memoizes async loads with concurrent request deduplication but clears cache on rejection, enabling retry workflows without mocking.

- **UI scaffolding** (`session-scaffold.tsx`, `start-screen.tsx`, `practice-experience.tsx`): Temporary components to drive the session loop while the designed round builder (#145) and scoreboard reveal (#146) are in progress. Handles pool loading states, error recovery, and phase transitions.

- **Practice route** (`[topic]/page.tsx`, `page.tsx`): Server-rendered entry points with static param generation and metadata. Client-side `PracticeExperience` component orchestrates prefetching and session lifecycle.

- **Scoring selectors**: Export functions to compute session-level metrics (blank count, words correct, pooled sound accuracy, topic sound tally) from round and score data.

- **Header navigation**: Added Practice link to main navigation.

- **Refactored tier-2 loader** (`phoneme-lookup/shared.ts`): Extracted lazy chunk loading into `createRetryableLoader` for consistency.

## Notable Details

- Pool loading is the sole gate to session start—no session begins without a ready pool.
- Leaving the route abandons the session by design (#140); no resume functionality.
- Sound accuracy is pooled across the session (not averaged per word) so skipping never beats attempting.
- Deterministic session generation via seeded RNG enables reproducible test assertions and future replay/sharing features.
- Stale pool loads that resolve after topic changes are dropped to prevent race conditions.

https://claude.ai/code/session_01VfohFRrKtN6mp1YFXFgCND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Practice area with topic-specific sessions.
  - Added topic details, session controls, loading states, retries, and invalid-topic handling.
  - Added round navigation, answer editing, submission, scoring, accuracy summaries, and review results.
  - Added Practice navigation to the application header.
  - Added a “Start over” recovery option for unexpected practice errors.

- **Bug Fixes**
  - Improved data-loading reliability with shared requests and automatic retries after failures.

- **Tests**
  - Added comprehensive coverage for practice sessions, scoring, loading, retries, and review calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->