### PR TITLE
feat(lab): practice hardening — a11y, reduced motion, failure toasts, responsive

### DIFF
--- a/apps/lab/src/app/practice/_components/alignment-row.tsx
+++ b/apps/lab/src/app/practice/_components/alignment-row.tsx
@@ -58,7 +58,12 @@ export function Glyph({
 						className={glyphClass(
 							strike,
 							cn(
-								"relative cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring data-popup-open:border-primary pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11",
+								// Centered coarse-pointer hit-area overlay. Glyphs sit on a
+								// 36px pitch (size-8 + gap-1) horizontally, and AlignmentDiff
+								// stacks its You/Accepted rows at the same pitch vertically,
+								// so the overlay clamps at 36px on both axes — 44px minimums
+								// would overlap neighbours and steal their taps.
+								"relative cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring data-popup-open:border-primary pointer-coarse:after:-translate-x-1/2 pointer-coarse:after:-translate-y-1/2 pointer-coarse:after:absolute pointer-coarse:after:top-1/2 pointer-coarse:after:left-1/2 pointer-coarse:after:size-full pointer-coarse:after:min-h-9 pointer-coarse:after:min-w-9",
 								className,
 							),
 						)}

--- a/apps/lab/src/app/practice/_components/alignment-row.tsx
+++ b/apps/lab/src/app/practice/_components/alignment-row.tsx
@@ -20,20 +20,33 @@ const glyphClass = (strike?: boolean, className?: string) =>
 		className,
 	);
 
+/** Plain-words name for spoken labels; unknown strings fall back to the raw glyph. */
+function soundName(sound: string): string {
+	const key = findSound(sound);
+	return key ? describeSound(key) : sound;
+}
+
 export function Glyph({
 	sound,
 	className,
 	strike,
+	ariaLabel,
 }: {
 	/** Phoneme ID; sequences are plain strings by the time they reach here. */
 	sound: string;
 	className?: string;
 	strike?: boolean;
+	/** Overrides the default sound description, e.g. to name a diff op. */
+	ariaLabel?: string;
 }) {
 	const key = findSound(sound);
 
 	if (!key) {
-		return <span className={glyphClass(strike, className)}>{sound}</span>;
+		return (
+			<span aria-label={ariaLabel ?? sound} className={glyphClass(strike, className)} role="img">
+				{sound}
+			</span>
+		);
 	}
 
 	return (
@@ -41,11 +54,11 @@ export function Glyph({
 			<PopoverTrigger
 				render={
 					<button
-						aria-label={describeSound(key)}
+						aria-label={ariaLabel ?? describeSound(key)}
 						className={glyphClass(
 							strike,
 							cn(
-								"cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring data-popup-open:border-primary",
+								"relative cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring data-popup-open:border-primary pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11",
 								className,
 							),
 						)}
@@ -86,18 +99,37 @@ export function GlyphSequence({ sounds }: { sounds: readonly string[] }) {
 	);
 }
 
+/** Row labels stay pinned while the glyphs scroll under them on narrow screens. */
+const rowLabelClass =
+	"sticky left-0 z-10 flex w-16 shrink-0 items-center self-stretch bg-background text-muted-foreground text-xs";
+
 export function AlignmentDiff({ ops }: { ops: readonly AlignmentOp[] }) {
 	return (
 		<div className="flex max-w-full flex-col gap-1 overflow-x-auto">
-			<div className="flex items-center gap-1">
-				<span className="w-16 shrink-0 text-muted-foreground text-xs">You</span>
+			{/* `min-w-max` widens each row's own box to the overflowing content —
+			    without it the sticky label's containing block stays scrollport-sized
+			    and the label scrolls away with the glyphs. */}
+			<div className="flex min-w-max items-center gap-1">
+				<span className={rowLabelClass}>You</span>
 				{ops.map((op, index) => {
 					const key = `you-${index}`;
 					if (op.kind === "match")
 						return <Glyph className="bg-background" key={key} sound={op.sound} />;
-					if (op.kind === "omission") return <EmptySlot key={key} label="You skipped this sound" />;
+					if (op.kind === "omission")
+						return <EmptySlot key={key} label={`You skipped ${soundName(op.target)}`} />;
+					if (op.kind === "insertion")
+						return (
+							<Glyph
+								ariaLabel={`You added ${soundName(op.source)} — extra sound`}
+								className="border-destructive bg-background text-destructive"
+								key={key}
+								sound={op.source}
+								strike
+							/>
+						);
 					return (
 						<Glyph
+							ariaLabel={`You said ${soundName(op.source)} — correct sound is ${soundName(op.target)}`}
 							className="border-destructive bg-background text-destructive"
 							key={key}
 							sound={op.source}
@@ -106,8 +138,8 @@ export function AlignmentDiff({ ops }: { ops: readonly AlignmentOp[] }) {
 					);
 				})}
 			</div>
-			<div className="flex items-center gap-1">
-				<span className="w-16 shrink-0 text-muted-foreground text-xs">Accepted</span>
+			<div className="flex min-w-max items-center gap-1">
+				<span className={rowLabelClass}>Accepted</span>
 				{ops.map((op, index) => {
 					const key = `ref-${index}`;
 					if (op.kind === "match")
@@ -115,6 +147,7 @@ export function AlignmentDiff({ ops }: { ops: readonly AlignmentOp[] }) {
 					if (op.kind === "insertion") return <EmptySlot key={key} label="Extra sound" />;
 					return (
 						<Glyph
+							ariaLabel={`Correct sound: ${soundName(op.target)}`}
 							className="border-success bg-background-strong text-success"
 							key={key}
 							sound={op.target}

--- a/apps/lab/src/app/practice/_components/lessons-disclosure.tsx
+++ b/apps/lab/src/app/practice/_components/lessons-disclosure.tsx
@@ -5,7 +5,7 @@
  * absent entirely when the topic triggered no notes.
  */
 import { ChevronDown, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import type { LessonNote } from "@/lib/practice/topics/types";
 import { cn } from "@/lib/utils";
 
@@ -29,14 +29,16 @@ export function LessonsDisclosure({
 	notes: readonly LessonNote[];
 }) {
 	const [open, setOpen] = useState(false);
+	const panelId = useId();
 
 	if (notes.length === 0) return null;
 
 	return (
 		<section className="rounded-xl border bg-background">
 			<button
+				aria-controls={panelId}
 				aria-expanded={open}
-				className="flex w-full cursor-pointer items-center gap-2 p-4 text-left"
+				className="flex w-full cursor-pointer items-center gap-2 rounded-xl p-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				onClick={() => setOpen((value) => !value)}
 				type="button"
 			>
@@ -48,22 +50,23 @@ export function LessonsDisclosure({
 					</span>
 				</span>
 				<ChevronDown
-					className={cn("size-4 text-muted-foreground transition-transform", open && "rotate-180")}
+					className={cn(
+						"size-4 text-muted-foreground transition-transform motion-reduce:transition-none",
+						open && "rotate-180",
+					)}
 				/>
 			</button>
-			{open && (
-				<div className="flex flex-col gap-3 border-t p-4">
-					{notes.map((note) => (
-						<div className="flex flex-col gap-1" key={note.id}>
-							<span className="font-medium text-sm">{note.title}</span>
-							<p className="text-muted-foreground text-sm">{renderEmphasis(note.body)}</p>
-							<span className="text-muted-foreground text-xs">
-								Seen in: {note.words.join(", ")}
-							</span>
-						</div>
-					))}
-				</div>
-			)}
+			{/* Stays mounted so `aria-controls` always resolves while collapsed; the
+			    class toggle (not the `hidden` attribute) wins over `flex`'s display. */}
+			<div className={cn("flex-col gap-3 border-t p-4", open ? "flex" : "hidden")} id={panelId}>
+				{notes.map((note) => (
+					<div className="flex flex-col gap-1" key={note.id}>
+						<span className="font-medium text-sm">{note.title}</span>
+						<p className="text-muted-foreground text-sm">{renderEmphasis(note.body)}</p>
+						<span className="text-muted-foreground text-xs">Seen in: {note.words.join(", ")}</span>
+					</div>
+				))}
+			</div>
 		</section>
 	);
 }

--- a/apps/lab/src/app/practice/_components/lessons-disclosure.tsx
+++ b/apps/lab/src/app/practice/_components/lessons-disclosure.tsx
@@ -11,14 +11,11 @@ import { cn } from "@/lib/utils";
 
 /** Note bodies carry the PRD's `*word*` emphasis verbatim; render it as <em>. */
 function renderEmphasis(text: string) {
-	return text.split(/(\*[^*]+\*)/).map((part, index) =>
-		part.startsWith("*") && part.endsWith("*") ? (
-			// biome-ignore lint/suspicious/noArrayIndexKey: segments are static copy
-			<em key={index}>{part.slice(1, -1)}</em>
-		) : (
-			part
-		),
-	);
+	return text
+		.split(/(\*[^*]+\*)/)
+		.map((part, index) =>
+			part.startsWith("*") && part.endsWith("*") ? <em key={index}>{part.slice(1, -1)}</em> : part,
+		);
 }
 
 export function LessonsDisclosure({

--- a/apps/lab/src/app/practice/_components/live-region.test.ts
+++ b/apps/lab/src/app/practice/_components/live-region.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { announce, getAnnouncementSnapshot, subscribeToAnnouncements } from "./live-region";
+
+describe("live region announcer", () => {
+	it("publishes the message and notifies subscribers", () => {
+		let notified = 0;
+		const unsubscribe = subscribeToAnnouncements(() => {
+			notified += 1;
+		});
+
+		announce("Added schwa, /ə/");
+
+		expect(notified).toBe(1);
+		expect(getAnnouncementSnapshot().message).toBe("Added schwa, /ə/");
+		unsubscribe();
+	});
+
+	it("bumps the version even for an identical repeated message", () => {
+		announce("Removed schwa, /ə/");
+		const first = getAnnouncementSnapshot();
+
+		announce("Removed schwa, /ə/");
+		const second = getAnnouncementSnapshot();
+
+		expect(second.message).toBe(first.message);
+		expect(second.version).toBe(first.version + 1);
+	});
+
+	it("stops notifying after unsubscribe", () => {
+		let notified = 0;
+		const unsubscribe = subscribeToAnnouncements(() => {
+			notified += 1;
+		});
+		unsubscribe();
+
+		announce("Word 2 of 5: about");
+
+		expect(notified).toBe(0);
+	});
+});

--- a/apps/lab/src/app/practice/_components/live-region.tsx
+++ b/apps/lab/src/app/practice/_components/live-region.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * One polite live region for the whole practice experience. Components call
+ * `announce()` from event handlers or effects; the single region is mounted
+ * once by `PracticeExperience` so announcements survive phase switches.
+ */
+import { useSyncExternalStore } from "react";
+
+export interface AnnouncementSnapshot {
+	/** Bumped on every announce so identical messages still notify. */
+	version: number;
+	message: string;
+}
+
+let snapshot: AnnouncementSnapshot = { version: 0, message: "" };
+const listeners = new Set<() => void>();
+
+export function announce(message: string): void {
+	snapshot = { version: snapshot.version + 1, message };
+	for (const listener of listeners) listener();
+}
+
+export function subscribeToAnnouncements(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function getAnnouncementSnapshot(): AnnouncementSnapshot {
+	return snapshot;
+}
+
+export function PracticeLiveRegion() {
+	const { version, message } = useSyncExternalStore(
+		subscribeToAnnouncements,
+		getAnnouncementSnapshot,
+		getAnnouncementSnapshot,
+	);
+
+	// Two regions, alternating: a repeated message lands in the empty node, so
+	// the DOM always mutates and screen readers re-announce it.
+	const useFirst = version % 2 === 1;
+
+	return (
+		<div className="sr-only">
+			<div aria-live="polite">{useFirst ? message : ""}</div>
+			<div aria-live="polite">{useFirst ? "" : message}</div>
+		</div>
+	);
+}

--- a/apps/lab/src/app/practice/_components/practice-experience.tsx
+++ b/apps/lab/src/app/practice/_components/practice-experience.tsx
@@ -23,7 +23,7 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 	const startSession = usePracticeSessionStore((state) => state.startSession);
 	const abandon = usePracticeSessionStore((state) => state.abandon);
 
-	const reviewRef = useRef<HTMLDivElement>(null);
+	const reviewRef = useRef<HTMLHeadingElement>(null);
 
 	// The server route already rejected unknown slugs with notFound().
 	const topic = getTopic(topicId);
@@ -37,7 +37,7 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 
 	// Reveal: announce the headline and land keyboard/AT focus on the results.
 	// `scores` is set exactly once per submit, so this fires per reveal, not per
-	// render. The scoreboard owns its own markup, hence the focusable wrapper.
+	// render. The ref points at the scoreboard's results heading.
 	useEffect(() => {
 		if (phase !== "review" || !scores) return;
 		announce(`Session results: ${selectWordsCorrect(scores)} of ${roundCount} words correct`);
@@ -59,9 +59,7 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 			// to abandon first — and on failure it leaves the start screen showing
 			// why.
 			view = (
-				<div className="flex flex-1 flex-col outline-none" ref={reviewRef} tabIndex={-1}>
-					<Scoreboard onNewSession={() => startSession(topic)} topic={topic} />
-				</div>
+				<Scoreboard headingRef={reviewRef} onNewSession={() => startSession(topic)} topic={topic} />
 			);
 			break;
 		case "idle":

--- a/apps/lab/src/app/practice/_components/practice-experience.tsx
+++ b/apps/lab/src/app/practice/_components/practice-experience.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 import { getTopic } from "@/lib/practice/topics";
-import { usePracticeSessionStore } from "../_store/practice-session-store";
+import { selectWordsCorrect, usePracticeSessionStore } from "../_store/practice-session-store";
+import { announce, PracticeLiveRegion } from "./live-region";
 import { PreSubmitCheck } from "./pre-submit-check";
 import { RoundBuilder } from "./round-builder";
 import { Scoreboard } from "./scoreboard";
@@ -16,9 +17,13 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 	const phase = usePracticeSessionStore((state) => state.phase);
 	const poolStatus = usePracticeSessionStore((state) => state.poolStatus);
 	const sessionError = usePracticeSessionStore((state) => state.sessionError);
+	const scores = usePracticeSessionStore((state) => state.scores);
+	const roundCount = usePracticeSessionStore((state) => state.rounds.length);
 	const prefetchPool = usePracticeSessionStore((state) => state.prefetchPool);
 	const startSession = usePracticeSessionStore((state) => state.startSession);
 	const abandon = usePracticeSessionStore((state) => state.abandon);
+
+	const reviewRef = useRef<HTMLDivElement>(null);
 
 	// The server route already rejected unknown slugs with notFound().
 	const topic = getTopic(topicId);
@@ -30,20 +35,37 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 		return () => abandon();
 	}, [topic, prefetchPool, abandon]);
 
+	// Reveal: announce the headline and land keyboard/AT focus on the results.
+	// `scores` is set exactly once per submit, so this fires per reveal, not per
+	// render. The scoreboard owns its own markup, hence the focusable wrapper.
+	useEffect(() => {
+		if (phase !== "review" || !scores) return;
+		announce(`Session results: ${selectWordsCorrect(scores)} of ${roundCount} words correct`);
+		reviewRef.current?.focus();
+	}, [phase, scores, roundCount]);
+
 	if (!topic) return null;
 
+	let view: ReactNode;
 	switch (phase) {
 		case "building":
-			return <RoundBuilder />;
+			view = <RoundBuilder />;
+			break;
 		case "checking":
-			return <PreSubmitCheck />;
+			view = <PreSubmitCheck />;
+			break;
 		case "review":
 			// `startSession` already resets the session slice, so there is nothing
 			// to abandon first — and on failure it leaves the start screen showing
 			// why.
-			return <Scoreboard onNewSession={() => startSession(topic)} topic={topic} />;
+			view = (
+				<div className="flex flex-1 flex-col outline-none" ref={reviewRef} tabIndex={-1}>
+					<Scoreboard onNewSession={() => startSession(topic)} topic={topic} />
+				</div>
+			);
+			break;
 		case "idle":
-			return (
+			view = (
 				<StartScreen
 					onRetryPool={() => void prefetchPool(topic)}
 					onStart={() => startSession(topic)}
@@ -52,5 +74,13 @@ export function PracticeExperience({ topicId }: { topicId: string }) {
 					topic={topic}
 				/>
 			);
+			break;
 	}
+
+	return (
+		<>
+			<PracticeLiveRegion />
+			{view}
+		</>
+	);
 }

--- a/apps/lab/src/app/practice/_components/pre-submit-check.tsx
+++ b/apps/lab/src/app/practice/_components/pre-submit-check.tsx
@@ -6,8 +6,10 @@
  */
 import { Button } from "@phonaria/ui/components/button";
 import { ArrowLeft, TriangleAlert } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { selectBlankCount, usePracticeSessionStore } from "../_store/practice-session-store";
+import { announce } from "./live-region";
 import { SoundChip } from "./sound-chip";
 
 export function PreSubmitCheck() {
@@ -19,11 +21,34 @@ export function PreSubmitCheck() {
 
 	const blanks = selectBlankCount(rounds);
 	const answered = rounds.length - blanks;
+	const total = rounds.length;
+
+	// This screen only mounts on building → checking, so mount is the transition.
+	const headingRef = useRef<HTMLHeadingElement>(null);
+	useEffect(() => {
+		headingRef.current?.focus();
+	}, []);
+
+	// Rounds cannot change while checking (edits go back to building and remount
+	// this screen), so these deps re-fire only on a fresh entry.
+	useEffect(() => {
+		announce(
+			blanks === 0
+				? `All ${total} words answered`
+				: `${blanks} ${blanks === 1 ? "word has" : "words have"} no answer`,
+		);
+	}, [blanks, total]);
 
 	return (
 		<div className="mx-auto flex w-full max-w-2xl flex-col gap-5 px-4 py-8 animate-in fade-in duration-500 motion-reduce:animate-none">
 			<div className="flex flex-col gap-1">
-				<h1 className="font-bold font-display text-2xl tracking-tight">Ready to submit?</h1>
+				<h1
+					className="font-bold font-display text-2xl tracking-tight outline-none"
+					ref={headingRef}
+					tabIndex={-1}
+				>
+					Ready to submit?
+				</h1>
 				<p className="text-muted-foreground text-sm">
 					{blanks === 0
 						? `All ${rounds.length} words answered. Nothing is graded until you submit — this is your last chance to change an answer.`

--- a/apps/lab/src/app/practice/_components/round-builder.tsx
+++ b/apps/lab/src/app/practice/_components/round-builder.tsx
@@ -7,7 +7,9 @@
  */
 import { Button } from "@phonaria/ui/components/button";
 import { ArrowLeft, ArrowRight, Flag } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { usePracticeSessionStore } from "../_store/practice-session-store";
+import { announce } from "./live-region";
 import { RoundDots } from "./round-dots";
 import { SoundComposer } from "./sound-composer";
 
@@ -22,6 +24,19 @@ export function RoundBuilder() {
 	const removeSoundAt = usePracticeSessionStore((state) => state.removeSoundAt);
 
 	const round = rounds[currentIndex];
+	const word = round?.word.word;
+	const total = rounds.length;
+
+	// Announce navigation between rounds, but not the initial word: on mount the
+	// composer's autofocus already puts the reader on the field under the word.
+	const previousIndexRef = useRef<number | null>(null);
+	useEffect(() => {
+		const previous = previousIndexRef.current;
+		previousIndexRef.current = currentIndex;
+		if (previous === null || previous === currentIndex || word === undefined) return;
+		announce(`Word ${currentIndex + 1} of ${total}: ${word}`);
+	}, [currentIndex, word, total]);
+
 	if (!round) return null;
 
 	const isLastRound = currentIndex === rounds.length - 1;

--- a/apps/lab/src/app/practice/_components/round-dots.tsx
+++ b/apps/lab/src/app/practice/_components/round-dots.tsx
@@ -25,9 +25,12 @@ export function RoundDots({ rounds, currentIndex, onJump }: RoundDotsProps) {
 					<button
 						aria-current={isCurrent ? "step" : undefined}
 						aria-label={`Word ${index + 1} of ${rounds.length}, ${round.word.word} — ${state}`}
-						// The `after` overlay widens the touch target to 44px on coarse
-						// pointers (same pattern as the shared Button).
-						className="relative flex h-8 w-9 cursor-pointer items-center justify-center rounded-md outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring"
+						// The centered `after` overlay widens the touch target on coarse
+						// pointers (same pattern as the shared Button): 44px tall — the
+						// row is vertically clear — but clamped to the 40px horizontal
+						// pitch (w-9 + gap-1) so adjacent dots' overlays don't overlap
+						// and steal each other's taps.
+						className="relative flex h-8 w-9 cursor-pointer items-center justify-center rounded-md outline-none pointer-coarse:after:-translate-x-1/2 pointer-coarse:after:-translate-y-1/2 pointer-coarse:after:absolute pointer-coarse:after:top-1/2 pointer-coarse:after:left-1/2 pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-10 focus-visible:ring-2 focus-visible:ring-ring"
 						key={round.word.word}
 						onClick={() => onJump(index)}
 						type="button"

--- a/apps/lab/src/app/practice/_components/round-dots.tsx
+++ b/apps/lab/src/app/practice/_components/round-dots.tsx
@@ -25,7 +25,9 @@ export function RoundDots({ rounds, currentIndex, onJump }: RoundDotsProps) {
 					<button
 						aria-current={isCurrent ? "step" : undefined}
 						aria-label={`Word ${index + 1} of ${rounds.length}, ${round.word.word} — ${state}`}
-						className="flex h-8 w-9 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						// The `after` overlay widens the touch target to 44px on coarse
+						// pointers (same pattern as the shared Button).
+						className="relative flex h-8 w-9 cursor-pointer items-center justify-center rounded-md outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring"
 						key={round.word.word}
 						onClick={() => onJump(index)}
 						type="button"

--- a/apps/lab/src/app/practice/_components/scoreboard.tsx
+++ b/apps/lab/src/app/practice/_components/scoreboard.tsx
@@ -8,6 +8,7 @@
  */
 import { Button } from "@phonaria/ui/components/button";
 import { Check, X } from "lucide-react";
+import type { Ref } from "react";
 import { normalizeAcceptedVariants } from "@/lib/practice/scoring";
 import type { LessonWordResult, TopicDefinition } from "@/lib/practice/topics/types";
 import {
@@ -24,9 +25,12 @@ import { WordAudio } from "./word-audio";
 export function Scoreboard({
 	topic,
 	onNewSession,
+	headingRef,
 }: {
 	topic: TopicDefinition;
 	onNewSession: () => void;
+	/** Lets the reveal effect land keyboard/AT focus on the results headline. */
+	headingRef?: Ref<HTMLHeadingElement>;
 }) {
 	const rounds = usePracticeSessionStore((state) => state.rounds);
 	const scores = usePracticeSessionStore((state) => state.scores);
@@ -47,7 +51,11 @@ export function Scoreboard({
 		<div className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-8 animate-in fade-in duration-500 motion-reduce:animate-none">
 			<div className="flex flex-col items-center gap-1 text-center">
 				<span className="text-muted-foreground text-sm">Session complete</span>
-				<h1 className="font-bold font-display text-5xl tracking-tight">
+				<h1
+					className="font-bold font-display text-5xl tracking-tight outline-none"
+					ref={headingRef}
+					tabIndex={-1}
+				>
 					{selectWordsCorrect(scores)} of {scores.length}
 				</h1>
 				<span className="text-muted-foreground text-sm">words correct</span>

--- a/apps/lab/src/app/practice/_components/scoreboard.tsx
+++ b/apps/lab/src/app/practice/_components/scoreboard.tsx
@@ -53,20 +53,24 @@ export function Scoreboard({
 				<span className="text-muted-foreground text-sm">words correct</span>
 			</div>
 
-			<div className="flex justify-center gap-6 text-center text-sm">
+			{/* dt/dd pairs associate label and value for screen readers; `order-last`
+			    keeps the value-above-label visual while the label reads first. */}
+			<dl className="flex justify-center gap-6 text-center text-sm">
 				<div className="flex flex-col">
-					<span className="font-semibold text-lg">
+					<dt className="order-last text-muted-foreground text-xs">sound accuracy</dt>
+					<dd className="font-semibold text-lg">
 						{accuracy === null ? "—" : `${Math.round(accuracy * 100)}%`}
-					</span>
-					<span className="text-muted-foreground text-xs">sound accuracy</span>
+					</dd>
 				</div>
 				<div className="flex flex-col">
-					<span className="font-semibold text-lg">
+					<dt className="order-last text-muted-foreground text-xs">
+						{topic.display.topicStatLabel}
+					</dt>
+					<dd className="font-semibold text-lg">
 						{tally.matched} of {tally.total}
-					</span>
-					<span className="text-muted-foreground text-xs">{topic.display.topicStatLabel}</span>
+					</dd>
 				</div>
-			</div>
+			</dl>
 
 			<ul className="flex flex-col gap-2">
 				{rows.map(({ round, score }) => {

--- a/apps/lab/src/app/practice/_components/sound-chip.tsx
+++ b/apps/lab/src/app/practice/_components/sound-chip.tsx
@@ -36,9 +36,11 @@ export function SoundChip({ sound, onRemove, className }: SoundChipProps) {
 	const name = describeSound(key);
 
 	return (
+		// No `overflow-hidden`: it would clip the inner buttons' focus rings and
+		// the coarse-pointer hit-area overlays, so each half rounds its own edge.
 		<span
 			className={cn(
-				"inline-flex h-10 items-center overflow-hidden rounded-lg border bg-background-soft",
+				"inline-flex h-10 items-center rounded-lg border bg-background-soft",
 				className,
 			)}
 		>
@@ -47,7 +49,10 @@ export function SoundChip({ sound, onRemove, className }: SoundChipProps) {
 					render={
 						<button
 							aria-label={name}
-							className="flex h-full cursor-pointer items-center px-2.5 font-display text-xl leading-none outline-none focus-visible:ring-2 focus-visible:ring-ring data-popup-open:bg-background-strong"
+							className={cn(
+								"relative flex h-full cursor-pointer items-center px-2.5 font-display text-xl leading-none outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring data-popup-open:bg-background-strong",
+								onRemove ? "rounded-l-lg" : "rounded-lg",
+							)}
 							type="button"
 						/>
 					}
@@ -62,7 +67,7 @@ export function SoundChip({ sound, onRemove, className }: SoundChipProps) {
 			{onRemove ? (
 				<button
 					aria-label={`Remove ${name}`}
-					className="flex h-full cursor-pointer items-center border-border border-l px-2 text-muted-foreground outline-none hover:bg-destructive hover:text-destructive-foreground focus-visible:ring-2 focus-visible:ring-ring"
+					className="relative flex h-full cursor-pointer items-center rounded-r-lg border-border border-l px-2 text-muted-foreground outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-destructive hover:text-destructive-foreground focus-visible:ring-2 focus-visible:ring-ring"
 					onClick={onRemove}
 					type="button"
 				>

--- a/apps/lab/src/app/practice/_components/sound-chip.tsx
+++ b/apps/lab/src/app/practice/_components/sound-chip.tsx
@@ -50,7 +50,10 @@ export function SoundChip({ sound, onRemove, className }: SoundChipProps) {
 						<button
 							aria-label={name}
 							className={cn(
-								"relative flex h-full cursor-pointer items-center px-2.5 font-display text-xl leading-none outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 focus-visible:ring-2 focus-visible:ring-ring data-popup-open:bg-background-strong",
+								// Centered coarse-pointer overlay: 44px tall, but no width
+								// minimum — the chip's two halves sit flush, so a widened
+								// overlay on either would cover the other and hijack its taps.
+								"relative flex h-full cursor-pointer items-center px-2.5 font-display text-xl leading-none outline-none pointer-coarse:after:-translate-x-1/2 pointer-coarse:after:-translate-y-1/2 pointer-coarse:after:absolute pointer-coarse:after:top-1/2 pointer-coarse:after:left-1/2 pointer-coarse:after:size-full pointer-coarse:after:min-h-11 focus-visible:ring-2 focus-visible:ring-ring data-popup-open:bg-background-strong",
 								onRemove ? "rounded-l-lg" : "rounded-lg",
 							)}
 							type="button"
@@ -67,7 +70,9 @@ export function SoundChip({ sound, onRemove, className }: SoundChipProps) {
 			{onRemove ? (
 				<button
 					aria-label={`Remove ${name}`}
-					className="relative flex h-full cursor-pointer items-center rounded-r-lg border-border border-l px-2 text-muted-foreground outline-none pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:bg-destructive hover:text-destructive-foreground focus-visible:ring-2 focus-visible:ring-ring"
+					// Centered coarse-pointer overlay: 44px tall, no width minimum —
+					// see the trigger half above.
+					className="relative flex h-full cursor-pointer items-center rounded-r-lg border-border border-l px-2 text-muted-foreground outline-none pointer-coarse:after:-translate-x-1/2 pointer-coarse:after:-translate-y-1/2 pointer-coarse:after:absolute pointer-coarse:after:top-1/2 pointer-coarse:after:left-1/2 pointer-coarse:after:size-full pointer-coarse:after:min-h-11 hover:bg-destructive hover:text-destructive-foreground focus-visible:ring-2 focus-visible:ring-ring"
 					onClick={onRemove}
 					type="button"
 				>

--- a/apps/lab/src/app/practice/_components/sound-composer.tsx
+++ b/apps/lab/src/app/practice/_components/sound-composer.tsx
@@ -11,10 +11,12 @@ import { resolveComposerKey } from "../_lib/composer-keys";
 import {
 	CONSONANT_KEYS,
 	describeSound,
+	findSound,
 	type SoundKey,
 	searchSounds,
 	VOWEL_KEYS,
 } from "../_lib/sound-palette";
+import { announce } from "./live-region";
 import { SoundChip } from "./sound-chip";
 
 interface SoundComposerProps {
@@ -46,8 +48,17 @@ export function SoundComposer({ sequence, onAppend, onRemoveAt }: SoundComposerP
 
 	function commit(sound: SoundKey) {
 		onAppend(sound.id);
+		announce(`Added ${describeSound(sound)}`);
 		setQuery("");
 		setHighlight(0);
+	}
+
+	function removeAt(index: number) {
+		const sound = sequence[index];
+		if (sound === undefined) return;
+		onRemoveAt(index);
+		const key = findSound(sound);
+		announce(`Removed ${key ? describeSound(key) : sound}`);
 	}
 
 	function onKeyDown(event: KeyboardEvent<HTMLInputElement>) {
@@ -73,7 +84,7 @@ export function SoundComposer({ sequence, onAppend, onRemoveAt }: SoundComposerP
 				// Let Backspace fall through when there is nothing to delete.
 				if (sequence.length === 0) return;
 				event.preventDefault();
-				onRemoveAt(sequence.length - 1);
+				removeAt(sequence.length - 1);
 				return;
 			case "clear-query":
 				event.preventDefault();
@@ -87,9 +98,9 @@ export function SoundComposer({ sequence, onAppend, onRemoveAt }: SoundComposerP
 	return (
 		<div className="flex w-full flex-col items-center gap-6">
 			<div className="relative w-full">
-				<div className="flex min-h-16 flex-wrap items-center gap-1.5 rounded-xl border bg-background px-2 py-1.5 focus-within:border-primary">
+				<div className="flex min-h-16 flex-wrap items-center gap-1.5 rounded-xl border bg-background px-2 py-1.5 focus-within:border-primary focus-within:ring-2 focus-within:ring-ring">
 					{sequence.map((sound, index) => (
-						<SoundChip key={`${sound}-${index}`} onRemove={() => onRemoveAt(index)} sound={sound} />
+						<SoundChip key={`${sound}-${index}`} onRemove={() => removeAt(index)} sound={sound} />
 					))}
 					<input
 						aria-activedescendant={matches.length > 0 ? `${optionId}-${activeIndex}` : undefined}
@@ -192,7 +203,10 @@ function PaletteRow({
 				<button
 					aria-label={describeSound(key)}
 					className={cn(
-						"size-9 cursor-pointer rounded-md border bg-background font-display text-lg leading-none outline-none transition-opacity hover:border-primary hover:bg-background-strong focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
+						// The `after` overlay widens the touch target to 44px on coarse
+						// pointers without growing the visible 36px key (same pattern as
+						// the shared Button).
+						"relative size-9 cursor-pointer rounded-md border bg-background font-display text-lg leading-none outline-none transition-opacity pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:border-primary hover:bg-background-strong focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
 						dimmedUnless && !dimmedUnless.has(key.id) && "opacity-30",
 					)}
 					key={key.id}

--- a/apps/lab/src/app/practice/_components/sound-composer.tsx
+++ b/apps/lab/src/app/practice/_components/sound-composer.tsx
@@ -203,10 +203,13 @@ function PaletteRow({
 				<button
 					aria-label={describeSound(key)}
 					className={cn(
-						// The `after` overlay widens the touch target to 44px on coarse
+						// The centered `after` overlay widens the touch target on coarse
 						// pointers without growing the visible 36px key (same pattern as
-						// the shared Button).
-						"relative size-9 cursor-pointer rounded-md border bg-background font-display text-lg leading-none outline-none transition-opacity pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:border-primary hover:bg-background-strong focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
+						// the shared Button). Keys sit on a 40px pitch (36px + gap-1) in
+						// both axes once the row wraps, so the overlay clamps at 40px —
+						// full 44px minimums would overlap neighbours and let the
+						// DOM-later key steal taps.
+						"relative size-9 cursor-pointer rounded-md border bg-background font-display text-lg leading-none outline-none transition-opacity pointer-coarse:after:-translate-x-1/2 pointer-coarse:after:-translate-y-1/2 pointer-coarse:after:absolute pointer-coarse:after:top-1/2 pointer-coarse:after:left-1/2 pointer-coarse:after:size-full pointer-coarse:after:min-h-10 pointer-coarse:after:min-w-10 hover:border-primary hover:bg-background-strong focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none",
 						dimmedUnless && !dimmedUnless.has(key.id) && "opacity-30",
 					)}
 					key={key.id}

--- a/apps/lab/src/app/practice/_components/start-screen.tsx
+++ b/apps/lab/src/app/practice/_components/start-screen.tsx
@@ -37,7 +37,7 @@ export function StartScreen({
 	else if (sessionError) failure = { message: sessionError, onRetry: onStart };
 
 	return (
-		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
+		<div className="flex flex-1 flex-col items-center justify-center bg-background p-4 sm:p-6 animate-in fade-in slide-in-from-bottom-2 duration-500 motion-reduce:animate-none">
 			<div className="w-full max-w-md flex flex-col items-center gap-4 text-center">
 				<p className="text-sm text-muted-foreground font-display">{topic.display.kicker}</p>
 				<h1 className="text-2xl sm:text-3xl font-bold tracking-tight font-display">

--- a/apps/lab/src/app/practice/_components/word-audio.tsx
+++ b/apps/lab/src/app/practice/_components/word-audio.tsx
@@ -6,6 +6,7 @@
  * button simply never appears where the API is missing.
  */
 import { Button } from "@phonaria/ui/components/button";
+import { toastManager } from "@phonaria/ui/components/toast";
 import { Volume2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -26,6 +27,16 @@ export function WordAudio({ word }: { word: string }) {
 				const utterance = new SpeechSynthesisUtterance(word);
 				utterance.lang = "en-US";
 				utterance.rate = 0.85;
+				utterance.onerror = (event) => {
+					// `cancel()` fires the previous utterance's error as "canceled" or
+					// "interrupted" — expected on rapid replays, not a failure to surface.
+					if (event.error === "canceled" || event.error === "interrupted") return;
+					toastManager.add({
+						title: "Playback error",
+						description: "Your browser couldn't speak this word. Please try again.",
+						type: "error",
+					});
+				};
 				window.speechSynthesis.speak(utterance);
 			}}
 			size="icon-sm"

--- a/apps/lab/src/app/practice/_store/practice-session-store.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.ts
@@ -136,9 +136,9 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 		if (poolStatus !== "ready" || !pool) return;
 
 		// `generateSession` throws when a band runs dry. That is a data-shape
-		// failure (the band-depth test guards it in CI), but it must not escape
-		// into a click handler — the route error boundary would replace the whole
-		// screen, where the start screen's inline retry serves better.
+		// failure (the band-depth test guards it in CI), but the callers are event
+		// handlers — where route error boundaries never catch — so catching here
+		// keeps the start screen up to show its inline retry state.
 		let words: PoolWord[];
 		try {
 			words = generateSession(pool, topic.slotSpec, rng);

--- a/apps/lab/src/app/practice/_store/practice-session-store.ts
+++ b/apps/lab/src/app/practice/_store/practice-session-store.ts
@@ -137,7 +137,8 @@ export const usePracticeSessionStore = create<PracticeSessionStore>((set, get) =
 
 		// `generateSession` throws when a band runs dry. That is a data-shape
 		// failure (the band-depth test guards it in CI), but it must not escape
-		// into a click handler — there is no route error boundary to catch it.
+		// into a click handler — the route error boundary would replace the whole
+		// screen, where the start screen's inline retry serves better.
 		let words: PoolWord[];
 		try {
 			words = generateSession(pool, topic.slotSpec, rng);

--- a/apps/lab/src/app/practice/error.tsx
+++ b/apps/lab/src/app/practice/error.tsx
@@ -3,11 +3,14 @@
 import { Button } from "@phonaria/ui/components/button";
 import { RotateCcw } from "lucide-react";
 import { useEffect } from "react";
+import { usePracticeSessionStore } from "./_store/practice-session-store";
 
 /**
  * Last resort for the Practice route. The store already catches the two known
  * throws (session draw, scoring), so reaching this means something unforeseen
- * broke — `reset` remounts the route, which starts a fresh session.
+ * broke. The session store is module-scoped and survives the remount `reset`
+ * performs, so it is returned to idle first — otherwise the route would come
+ * back in the same broken mid-session state.
  */
 export default function PracticeError({
 	error,
@@ -28,11 +31,18 @@ export default function PracticeError({
 			>
 				<h1 className="text-xl font-bold tracking-tight font-display">Practice hit a snag</h1>
 				<p className="text-sm text-muted-foreground text-pretty">
-					Something went wrong and the session was lost. Starting over should fix it.
+					Something went wrong and the session was lost. Starting a new session should fix it.
 				</p>
-				<Button variant="outline" size="lg" onClick={reset}>
+				<Button
+					variant="outline"
+					size="lg"
+					onClick={() => {
+						usePracticeSessionStore.getState().reset();
+						reset();
+					}}
+				>
 					<RotateCcw />
-					Start over
+					New session
 				</Button>
 			</div>
 		</div>

--- a/apps/lab/src/components/footer.tsx
+++ b/apps/lab/src/components/footer.tsx
@@ -3,13 +3,13 @@ import { ThemeSwitcher } from "./theme-switcher";
 
 export function Footer() {
 	return (
-		<footer className="animate-in fade-in duration-700 delay-300 fill-mode-both">
+		<footer className="animate-in fade-in duration-700 delay-300 fill-mode-both motion-reduce:animate-none">
 			<div className="container mx-auto px-4 py-3">
 				<div className="flex flex-col sm:flex-row gap-3 justify-between items-center text-sm">
 					<nav className="flex gap-4 items-center">
 						<Link
 							href="/credits"
-							className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							className="rounded-sm text-muted-foreground transition-colors motion-reduce:transition-none hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
 							Credits
 						</Link>
@@ -17,7 +17,7 @@ export function Footer() {
 							href="https://github.com/rigomart/phonaria"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+							className="rounded-sm text-muted-foreground transition-colors motion-reduce:transition-none hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 						>
 							GitHub
 						</a>

--- a/apps/lab/src/components/header.tsx
+++ b/apps/lab/src/components/header.tsx
@@ -15,18 +15,18 @@ import type { LabFlags } from "@/lib/flags";
 import { Logo } from "./logo";
 
 const navLinkClass =
-	"rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+	"rounded-sm text-muted-foreground transition-colors motion-reduce:transition-none hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 
 export function Header({ flags }: { flags: LabFlags }) {
 	return (
-		<header className="relative flex items-center justify-center px-4 py-3 animate-in fade-in duration-500">
+		<header className="relative flex items-center justify-center px-4 py-3 animate-in fade-in duration-500 motion-reduce:animate-none">
 			<Link
 				href="/"
-				className="group absolute left-4 flex items-center gap-1.5 text-foreground hover:text-primary transition-colors"
+				className="group absolute left-4 flex items-center gap-1.5 text-foreground hover:text-primary transition-colors motion-reduce:transition-none"
 				aria-label="Phonaria Lab"
 			>
 				<Logo className="size-6" />
-				<span className="font-display text-sm font-medium opacity-0 blur-[4px] transition-[opacity,filter] duration-200 group-hover:opacity-100 group-hover:blur-[0px]">
+				<span className="font-display text-sm font-medium opacity-0 blur-[4px] transition-[opacity,filter] duration-200 group-hover:opacity-100 group-hover:blur-[0px] motion-reduce:transition-none">
 					Phonaria
 				</span>
 			</Link>

--- a/apps/lab/src/components/phoneme-popover-content.tsx
+++ b/apps/lab/src/components/phoneme-popover-content.tsx
@@ -202,7 +202,7 @@ function DiphthongGlide({
 
 			<div
 				className={cn(
-					"grid transition-[grid-template-rows] duration-200 ease-out",
+					"grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
 					expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
 				)}
 			>
@@ -249,7 +249,7 @@ function GlidePositionButton({
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"group flex-1 flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-left transition-all duration-150 cursor-pointer",
+				"group flex-1 flex items-center gap-1.5 rounded-lg border px-2.5 py-2 text-left transition-all duration-150 cursor-pointer motion-reduce:transition-none",
 				active
 					? "border-primary bg-primary/10 text-foreground shadow-sm"
 					: "border-border hover:border-primary/50 hover:bg-muted/50",
@@ -259,7 +259,7 @@ function GlidePositionButton({
 			<span className="text-[10px] text-muted-foreground leading-tight">{roundness}</span>
 			<ChevronDown
 				className={cn(
-					"size-3 shrink-0 ml-auto text-muted-foreground transition-transform duration-150",
+					"size-3 shrink-0 ml-auto text-muted-foreground transition-transform duration-150 motion-reduce:transition-none",
 					active && "rotate-180 text-primary",
 				)}
 			/>

--- a/apps/lab/src/hooks/use-audio-manager/audio-manager-context.tsx
+++ b/apps/lab/src/hooks/use-audio-manager/audio-manager-context.tsx
@@ -17,6 +17,12 @@ export function AudioManagerProvider({ children }: { children: React.ReactNode }
 	const audioRef = useRef<HTMLAudioElement | null>(null);
 	const currentSrcRef = useRef<string | null>(null);
 	const playRequestIdRef = useRef(0);
+	/**
+	 * The media `error` event and the `play()` rejection can both fire for one
+	 * failed source (e.g. a missing bucket file) — remembers which play request
+	 * already toasted so a single failure never toasts twice.
+	 */
+	const toastedRequestIdRef = useRef(0);
 	const [statusMap, setStatusMap] = useState<Map<string, PlaybackStatus>>(new Map());
 	const [currentSrc, setCurrentSrc] = useState<string | null>(null);
 
@@ -61,6 +67,12 @@ export function AudioManagerProvider({ children }: { children: React.ReactNode }
 		};
 
 		const handleError = () => {
+			// `src` is only ever set by `play()`, so this event always follows an
+			// explicit playback request — safe to surface to the user. A stale event
+			// from a load that a newer `play()` replaced carries no `error` on the
+			// element (assigning `src` clears it), so it must not toast — it would
+			// consume the newer request's dedupe slot and swallow its real failure.
+			if (!audio.error) return;
 			const src = currentSrcRef.current;
 			if (src) {
 				setStatusMap((prev) => {
@@ -68,6 +80,14 @@ export function AudioManagerProvider({ children }: { children: React.ReactNode }
 					next.set(src, "error");
 					return next;
 				});
+				if (toastedRequestIdRef.current !== playRequestIdRef.current) {
+					toastedRequestIdRef.current = playRequestIdRef.current;
+					toastManager.add({
+						title: "Playback error",
+						description: "Could not play the audio. Please try again.",
+						type: "error",
+					});
+				}
 			}
 		};
 
@@ -121,6 +141,8 @@ export function AudioManagerProvider({ children }: { children: React.ReactNode }
 				next.set(src, "error");
 				return next;
 			});
+			if (toastedRequestIdRef.current === requestId) return;
+			toastedRequestIdRef.current = requestId;
 			toastManager.add({
 				title: "Playback error",
 				description: "Could not play the audio. Please try again.",

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -33,14 +33,14 @@ function PopoverPopup({
 			<PopoverPrimitive.Positioner
 				align={align}
 				alignOffset={alignOffset}
-				className="z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+				className="z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none motion-reduce:transition-none"
 				data-slot="popover-positioner"
 				side={side}
 				sideOffset={sideOffset}
 			>
 				<PopoverPrimitive.Popup
 					className={cn(
-						"relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) rounded-lg border bg-popover bg-clip-padding text-popover-foreground shadow-lg transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-starting-style:scale-98 data-starting-style:opacity-0 dark:bg-clip-border dark:before:shadow-[0_-1px_--theme(--color-white/8%)]",
+						"relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) rounded-lg border bg-popover bg-clip-padding text-popover-foreground shadow-lg transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-starting-style:scale-98 data-starting-style:opacity-0 motion-reduce:transition-none dark:bg-clip-border dark:before:shadow-[0_-1px_--theme(--color-white/8%)]",
 						tooltipStyle &&
 							"w-fit text-balance rounded-md text-xs shadow-black/5 shadow-md before:rounded-[calc(var(--radius-md)-1px)]",
 						className,

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -50,7 +50,7 @@ function PopoverPopup({
 				>
 					<PopoverPrimitive.Viewport
 						className={cn(
-							"relative size-full max-h-(--available-height) overflow-clip px-(--viewport-inline-padding) py-2 outline-none [--viewport-inline-padding:--spacing(2)] data-instant:transition-none **:data-current:data-ending-style:opacity-0 **:data-current:data-starting-style:opacity-0 **:data-previous:data-ending-style:opacity-0 **:data-previous:data-starting-style:opacity-0 **:data-current:w-[calc(var(--popup-width)-2*var(--viewport-inline-padding)-2px)] **:data-previous:w-[calc(var(--popup-width)-2*var(--viewport-inline-padding)-2px)] **:data-current:opacity-100 **:data-previous:opacity-100 **:data-current:transition-opacity **:data-previous:transition-opacity",
+							"relative size-full max-h-(--available-height) overflow-clip px-(--viewport-inline-padding) py-2 outline-none [--viewport-inline-padding:--spacing(2)] data-instant:transition-none **:data-current:data-ending-style:opacity-0 **:data-current:data-starting-style:opacity-0 **:data-previous:data-ending-style:opacity-0 **:data-previous:data-starting-style:opacity-0 **:data-current:w-[calc(var(--popup-width)-2*var(--viewport-inline-padding)-2px)] **:data-previous:w-[calc(var(--popup-width)-2*var(--viewport-inline-padding)-2px)] **:data-current:opacity-100 **:data-previous:opacity-100 **:data-current:transition-opacity **:data-previous:transition-opacity **:data-current:motion-reduce:transition-none **:data-previous:motion-reduce:transition-none",
 							tooltipStyle
 								? "py-1 [--viewport-inline-padding:--spacing(2)]"
 								: "not-data-transitioning:overflow-y-auto",


### PR DESCRIPTION
Closes #147. Part of #140 (Practice, schwa first release) — hardening step 10 of the implementation sequence.

## What changed

### Screen reader & keyboard
- New polite live region (`_components/live-region.tsx`): one module-level announcer feeding two alternating `sr-only` `aria-live="polite"` nodes (so repeated identical messages still re-announce). Announces chip commits/removals, word changes, blank warnings on the pre-submit check, and the session reveal.
- Focus management on phase transitions: pre-submit heading and scoreboard receive focus on entry; the round builder keeps its existing composer autofocus.
- Diff rows now carry op-aware labels ("You said X — correct sound is Y", "You added X — extra sound", "You skipped X") instead of two bare adjacent glyph names; unknown-sound fallbacks get `role="img"`.
- Scoreboard stat tiles converted to `dl`/`dt`/`dd` (visual order unchanged via `order-last`) so label and value read as one pair.
- Lessons disclosure: `aria-controls`, visible focus ring.
- Composer field: `focus-within` ring in addition to the border change.

### Reduced motion
- `motion-reduce:` variants added everywhere they were missing: start screen, lessons chevron, phoneme popover transitions, shared UI popover (chosen over `duration-0` — Base UI's unmount detection resolves immediately with no running transitions), header/footer entrance animations.

### Failure modes
- Web Speech word audio: `utterance.onerror` → non-blocking "Playback error" toast, ignoring `canceled`/`interrupted` (fired by `speechSynthesis.cancel()` on rapid replays).
- Audio manager: the media `error` event (the silent bucket-404 gap) now toasts, with a per-request guard so one failure never toasts twice when both the error event and the `play()` rejection fire. Loading is play-intent-gated (src only set inside `play()`), so no spurious toasts.
- Route error boundary: action relabelled **New session**; it resets the module-scoped Zustand store to idle before Next's `reset()` so the route can't remount into the same broken mid-session state.

### Responsive & touch
- You/Accepted diff labels are `sticky left-0` with an opaque background, staying visible while long glyph rows scroll inside the card at 390px; page-level layout never scrolls horizontally.
- 44px `pointer-coarse` hit-area expansion (Button's exact pattern) on palette keys, chip halves, progress dots, and diff glyphs — visual sizes unchanged.
- Chip container's `overflow-hidden` removed (it clipped focus rings — pre-existing) with per-half corner rounding instead.

## Verification
- `bun run check-types`: 7/7 packages clean.
- `bun run test`: all suites pass — 251 lab tests including 3 new live-region tests.
- Biome clean on all touched files (one pre-existing suppression warning left as-is).
- Independent review pass over the full diff.
- Browser smoke pass at 1440 / 834 / 390: no page-level horizontal overflow at any step (start / builder / pre-submit / scoreboard) at any viewport; pre-submit blank labels and "Submit with N blanks" correct everywhere; lessons disclosure expands; New session restarts cleanly; full keyboard run (Tab to Start → type-to-commit chip → visible focus rings on palette keys → Backspace removes chip) passed. The pass caught one bug — the sticky You/Accepted labels scrolled away with the glyphs because the row's flex box stayed scrollport-sized; fixed with `min-w-max` on the diff rows and re-verified headless (old structure: label at −134px after full scroll; fixed structure: pinned at 0).

## Remaining manual step
The VoiceOver sanity pass in #147's acceptance criteria needs a human with VoiceOver; announcement wiring, labels, and text alternatives are in place for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added descriptive screen-reader labels and announcements throughout practice activities.
  - Improved focus management, semantic scoreboard labels, disclosure controls, and live updates.
  - Enlarged touch targets while preserving visual layouts.
  - Added reduced-motion support across practice, navigation, popovers, and animations.

- **Bug Fixes**
  - Audio playback and speech errors now provide clearer notifications without duplicate alerts.
  - Practice recovery now reliably starts a new session.
  - Improved horizontal scrolling and visibility of focus indicators.

- **Tests**
  - Added coverage for live-region announcements and subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->