### PR TITLE
fix(lab): make practice announcements audible under VoiceOver

### DIFF
--- a/apps/lab/src/app/practice/_components/live-region.test.ts
+++ b/apps/lab/src/app/practice/_components/live-region.test.ts
@@ -48,12 +48,27 @@ describe("live region announcer", () => {
 		expect(second.version).toBe(first.version + 1);
 	});
 
-	it("delivers rapid announcements in order", () => {
+	it("coalesces announcements inside one delay window to the latest message", () => {
+		const before = getAnnouncementSnapshot().version;
 		announce("Added schwa, ə");
 		announce("Added as in let, l");
 		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
 
 		expect(getAnnouncementSnapshot().message).toBe("Added as in let, l");
+		expect(getAnnouncementSnapshot().version).toBe(before + 1);
+	});
+
+	it("restarts the delay when a newer announcement supersedes a pending one", () => {
+		announce("Word 3 of 5: typical");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS - 1);
+		announce("2 words have no answer");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS - 1);
+
+		expect(getAnnouncementSnapshot().message).not.toBe("2 words have no answer");
+
+		vi.advanceTimersByTime(1);
+
+		expect(getAnnouncementSnapshot().message).toBe("2 words have no answer");
 	});
 
 	it("stops notifying after unsubscribe", () => {

--- a/apps/lab/src/app/practice/_components/live-region.test.ts
+++ b/apps/lab/src/app/practice/_components/live-region.test.ts
@@ -1,29 +1,59 @@
-import { describe, expect, it } from "vitest";
-import { announce, getAnnouncementSnapshot, subscribeToAnnouncements } from "./live-region";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	ANNOUNCE_DELAY_MS,
+	announce,
+	getAnnouncementSnapshot,
+	subscribeToAnnouncements,
+} from "./live-region";
 
 describe("live region announcer", () => {
-	it("publishes the message and notifies subscribers", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.runAllTimers();
+		vi.useRealTimers();
+	});
+
+	it("publishes the message and notifies subscribers after the announce delay", () => {
 		let notified = 0;
 		const unsubscribe = subscribeToAnnouncements(() => {
 			notified += 1;
 		});
+		const before = getAnnouncementSnapshot();
 
-		announce("Added schwa, /ə/");
+		announce("Added schwa, ə");
+
+		expect(notified).toBe(0);
+		expect(getAnnouncementSnapshot()).toBe(before);
+
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
 
 		expect(notified).toBe(1);
-		expect(getAnnouncementSnapshot().message).toBe("Added schwa, /ə/");
+		expect(getAnnouncementSnapshot().message).toBe("Added schwa, ə");
 		unsubscribe();
 	});
 
 	it("bumps the version even for an identical repeated message", () => {
-		announce("Removed schwa, /ə/");
+		announce("Removed schwa, ə");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
 		const first = getAnnouncementSnapshot();
 
-		announce("Removed schwa, /ə/");
+		announce("Removed schwa, ə");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
 		const second = getAnnouncementSnapshot();
 
 		expect(second.message).toBe(first.message);
 		expect(second.version).toBe(first.version + 1);
+	});
+
+	it("delivers rapid announcements in order", () => {
+		announce("Added schwa, ə");
+		announce("Added as in let, l");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
+
+		expect(getAnnouncementSnapshot().message).toBe("Added as in let, l");
 	});
 
 	it("stops notifying after unsubscribe", () => {
@@ -34,6 +64,7 @@ describe("live region announcer", () => {
 		unsubscribe();
 
 		announce("Word 2 of 5: about");
+		vi.advanceTimersByTime(ANNOUNCE_DELAY_MS);
 
 		expect(notified).toBe(0);
 	});

--- a/apps/lab/src/app/practice/_components/live-region.tsx
+++ b/apps/lab/src/app/practice/_components/live-region.tsx
@@ -25,8 +25,15 @@ const listeners = new Set<() => void>();
  */
 export const ANNOUNCE_DELAY_MS = 150;
 
+let pendingAnnounce: ReturnType<typeof setTimeout> | null = null;
+
 export function announce(message: string): void {
-	setTimeout(() => {
+	// A newer announcement supersedes an undelivered one: flushing both within
+	// one delay window would re-batch them, and the newer message is the one
+	// describing the current state anyway.
+	if (pendingAnnounce !== null) clearTimeout(pendingAnnounce);
+	pendingAnnounce = setTimeout(() => {
+		pendingAnnounce = null;
 		snapshot = { version: snapshot.version + 1, message };
 		for (const listener of listeners) listener();
 	}, ANNOUNCE_DELAY_MS);

--- a/apps/lab/src/app/practice/_components/live-region.tsx
+++ b/apps/lab/src/app/practice/_components/live-region.tsx
@@ -16,9 +16,20 @@ export interface AnnouncementSnapshot {
 let snapshot: AnnouncementSnapshot = { version: 0, message: "" };
 const listeners = new Set<() => void>();
 
+/**
+ * VoiceOver drops polite live-region updates that land in the same
+ * accessibility-tree batch as other state changes — committing a typed sound
+ * collapses the search combobox, and VO speaks only "collapsed" (#158).
+ * Deferring the DOM mutation past that batch makes each announcement a
+ * discrete update VO reliably voices after the state-change speech.
+ */
+export const ANNOUNCE_DELAY_MS = 150;
+
 export function announce(message: string): void {
-	snapshot = { version: snapshot.version + 1, message };
-	for (const listener of listeners) listener();
+	setTimeout(() => {
+		snapshot = { version: snapshot.version + 1, message };
+		for (const listener of listeners) listener();
+	}, ANNOUNCE_DELAY_MS);
 }
 
 export function subscribeToAnnouncements(listener: () => void): () => void {

--- a/apps/lab/src/app/practice/_lib/sound-palette.test.ts
+++ b/apps/lab/src/app/practice/_lib/sound-palette.test.ts
@@ -57,11 +57,11 @@ describe("palette coverage", () => {
 
 describe("describeSound", () => {
 	it("leads with the learner's nickname when there is one", () => {
-		expect(describeSound(sound("AX"))).toBe("schwa, /ə/");
+		expect(describeSound(sound("AX"))).toBe("schwa, ə");
 	});
 
 	it("names the sound by an example word rather than articulatory jargon", () => {
-		expect(describeSound(sound("P"))).toBe("as in pat, /p/");
+		expect(describeSound(sound("P"))).toBe("as in pat, p");
 	});
 });
 

--- a/apps/lab/src/app/practice/_lib/sound-palette.ts
+++ b/apps/lab/src/app/practice/_lib/sound-palette.ts
@@ -150,13 +150,15 @@ export function findSound(id: string): SoundKey | undefined {
 }
 
 /**
- * Accessible name for a bare glyph: "schwa, /ə/". A screen reader cannot be
+ * Accessible name for a bare glyph: "schwa, ə". A screen reader cannot be
  * trusted to pronounce IPA, so plain words come first — not the articulatory
- * label, which stays in the dropdown row (#140).
+ * label, which stays in the dropdown row (#140). No /slashes/ around the IPA:
+ * VoiceOver reads them as "slash" on every key (#158). The bare symbol stays
+ * to disambiguate shared example words ("as in sun" is both s and n).
  */
 export function describeSound(sound: SoundKey): string {
 	const name = sound.nicknames[0] ?? `as in ${sound.examples[0]}`;
-	return `${name}, /${sound.ipa}/`;
+	return `${name}, ${sound.ipa}`;
 }
 
 /**

--- a/apps/lab/src/components/phoneme-popover-content.tsx
+++ b/apps/lab/src/components/phoneme-popover-content.tsx
@@ -51,9 +51,13 @@ export function PhonemePopoverContent({ phonemeId }: PhonemePopoverProps) {
 		<div className="flex flex-col gap-2 w-72">
 			<div className="flex items-center justify-between gap-2">
 				<div className="flex items-baseline gap-0.5 text-2xl font-medium">
-					<span className="text-muted-foreground/50">/</span>
+					<span aria-hidden="true" className="text-muted-foreground/50">
+						/
+					</span>
 					<span>{ipa}</span>
-					<span className="text-muted-foreground/50">/</span>
+					<span aria-hidden="true" className="text-muted-foreground/50">
+						/
+					</span>
 				</div>
 				{showAudio && <AudioControls path={`/audio/phonemes/${phonemeId}.ogg`} label={ipa} />}
 			</div>


### PR DESCRIPTION
Fixes the two defects found in the human VoiceOver pass for #158:

1. **IPA slashes spoken as "slash"** — `describeSound` now returns `schwa, ə` instead of `schwa, /ə/`; the bare IPA symbol stays to disambiguate shared example words ("as in sun" is both *s* and *n*). The phoneme popover's decorative slash spans are hidden from the accessibility tree. Visible IPA glyphs and notation are unchanged.
2. **Typed-sound commit spoke only "collapsed"** — the polite live-region update landed in the same accessibility-tree batch as the search combobox collapsing, and VoiceOver dropped it. `announce()` now defers the DOM mutation by 150 ms so each announcement is a discrete update voiced after the state-change speech; announcements inside one delay window coalesce to the newest message so they can't re-batch.

Covered by updated unit tests (deferral, coalescing, supersession, label format); full lab suite passes (253), types and lint clean. Smoke-tested in-browser: labels are slash-free and the typing path's "Added goose, u" lands in the live region.

**Re-test with VoiceOver** (the part automation can't judge): repeat step 2 of the script in [#158's checklist](https://github.com/rigomart/phonaria/issues/158#issuecomment-5225054751) — type `goose`, Enter, and confirm "Added goose, u" is actually voiced after the collapse — and spot-check that palette keys and the glyph popover no longer say "slash".

Refs #158