### PR TITLE
fix(lab): surface transcription lookup failures with retry

### DIFF
--- a/apps/lab/src/app/_components/transcription-display/index.tsx
+++ b/apps/lab/src/app/_components/transcription-display/index.tsx
@@ -23,8 +23,8 @@ interface WordColumnProps {
 }
 
 function WordColumn({ word, index }: WordColumnProps) {
-	const { selectedVariants, setVariant } = useG2PStore();
-	const selected = selectedVariants[word.wordIndex] ?? 0;
+	const selected = useG2PStore((s) => s.selectedVariants[word.wordIndex] ?? 0);
+	const setVariant = useG2PStore((s) => s.setVariant);
 	const currentVariant = useMemo(() => word.variants[selected] ?? [], [word.variants, selected]);
 	const isUnknown = word.source === "fallback";
 
@@ -100,11 +100,14 @@ function TranscriptionResults({
  *
  * Retry sits outside the `role="alert"` region: that region is assertive, and
  * swapping the button's icon and disabled state inside it makes some screen
- * readers re-announce the whole error on every click.
+ * readers re-announce the whole error on every click. The region is keyed by
+ * the settled-failure nonce so a retry that fails with the same kind still
+ * re-mounts the alert and gets announced.
  */
 export function TranscriptionDisplay() {
 	const { data: result } = useCurrentTranscription();
 	const lookupError = useG2PStore((s) => s.lookupError);
+	const lookupErrorNonce = useG2PStore((s) => s.lookupErrorNonce);
 	const isTranscribing = useG2PStore((s) => s.isTranscribing);
 	const { retry, isPending } = useTranscribe();
 	const isBusy = isPending || isTranscribing;
@@ -119,6 +122,7 @@ export function TranscriptionDisplay() {
 				<div className="flex flex-col items-center px-4 py-4">
 					<div className="w-full max-w-md flex flex-col items-center gap-3">
 						<div
+							key={`${lookupError}-${lookupErrorNonce}`}
 							role="alert"
 							className="w-full flex flex-col items-center gap-3 rounded-lg border border-border bg-muted p-4 text-center"
 						>

--- a/apps/lab/src/app/_components/transcription-display/index.tsx
+++ b/apps/lab/src/app/_components/transcription-display/index.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { useMemo } from "react";
-import type { TranscribedWord } from "@/lib/types/g2p";
-import { useCurrentTranscription } from "../../_hooks/use-transcribe";
-import { useG2PStore } from "../../_store/g2p-store";
+import { Button } from "@phonaria/ui/components/button";
+import { Spinner } from "@phonaria/ui/components/spinner";
+import { RotateCcw } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+import type { TranscribedWord, TranscriptionResult } from "@/lib/types/g2p";
+import { useCurrentTranscription, useTranscribe } from "../../_hooks/use-transcribe";
+import { type LookupErrorKind, useG2PStore } from "../../_store/g2p-store";
 import { EmptyState } from "./empty-state";
 import { IpaSequence } from "./ipa-sequence";
 import { VariantSelector } from "./variant-selector";
+
+const LOOKUP_ERROR_COPY: Record<LookupErrorKind, string> = {
+	wordlist: "We couldn't load the word list. Check your connection and try again.",
+	service: "We couldn't reach the lookup service. Please try again.",
+	unknown: "We couldn't finish transcribing that. Please try again.",
+};
 
 interface WordColumnProps {
 	word: TranscribedWord;
@@ -51,13 +60,23 @@ function WordColumn({ word, index }: WordColumnProps) {
 	);
 }
 
-export function TranscriptionDisplay() {
-	const { data: result } = useCurrentTranscription();
-
-	if (!result) return <EmptyState />;
-
+function TranscriptionResults({
+	result,
+	isStale,
+}: {
+	result: TranscriptionResult;
+	isStale: boolean;
+}) {
 	return (
 		<div className="flex flex-col items-center overflow-x-auto px-4 py-4">
+			{isStale ? (
+				<div className="mb-4">
+					<p className="text-xs text-muted-foreground">
+						Showing your last transcription for "{result.originalText}".
+					</p>
+				</div>
+			) : null}
+
 			<div className="flex flex-wrap justify-center gap-x-6 gap-y-4 md:gap-x-8 md:gap-y-6">
 				{result.words.map((word, wordIndex) => (
 					<WordColumn key={`${word.word}-${wordIndex}`} word={word} index={wordIndex} />
@@ -71,5 +90,48 @@ export function TranscriptionDisplay() {
 				<p className="text-xs text-muted-foreground">Click any phoneme for details</p>
 			</div>
 		</div>
+	);
+}
+
+/**
+ * A failed lookup shows an inline alert with Retry above whatever result was
+ * already on screen (#163). The empty state is suppressed while erroring so the
+ * learner's attention stays on the recovery action instead of on example chips.
+ *
+ * Retry sits outside the `role="alert"` region: that region is assertive, and
+ * swapping the button's icon and disabled state inside it makes some screen
+ * readers re-announce the whole error on every click.
+ */
+export function TranscriptionDisplay() {
+	const { data: result } = useCurrentTranscription();
+	const lookupError = useG2PStore((s) => s.lookupError);
+	const isTranscribing = useG2PStore((s) => s.isTranscribing);
+	const { retry, isPending } = useTranscribe();
+	const isBusy = isPending || isTranscribing;
+
+	let body: ReactNode = null;
+	if (result) body = <TranscriptionResults result={result} isStale={lookupError !== null} />;
+	else if (!lookupError) body = <EmptyState />;
+
+	return (
+		<>
+			{lookupError ? (
+				<div className="flex flex-col items-center px-4 py-4">
+					<div className="w-full max-w-md flex flex-col items-center gap-3">
+						<div
+							role="alert"
+							className="w-full flex flex-col items-center gap-3 rounded-lg border border-border bg-muted p-4 text-center"
+						>
+							<p className="text-sm text-foreground">{LOOKUP_ERROR_COPY[lookupError]}</p>
+						</div>
+						<Button variant="outline" onClick={retry} disabled={isBusy} aria-busy={isBusy}>
+							{isBusy ? <Spinner /> : <RotateCcw />}
+							Retry
+						</Button>
+					</div>
+				</div>
+			) : null}
+			{body}
+		</>
 	);
 }

--- a/apps/lab/src/app/_components/transcription-display/index.tsx
+++ b/apps/lab/src/app/_components/transcription-display/index.tsx
@@ -94,15 +94,11 @@ function TranscriptionResults({
 }
 
 /**
- * A failed lookup shows an inline alert with Retry above whatever result was
- * already on screen (#163). The empty state is suppressed while erroring so the
- * learner's attention stays on the recovery action instead of on example chips.
- *
- * Retry sits outside the `role="alert"` region: that region is assertive, and
- * swapping the button's icon and disabled state inside it makes some screen
- * readers re-announce the whole error on every click. The region is keyed by
- * the settled-failure nonce so a retry that fails with the same kind still
- * re-mounts the alert and gets announced.
+ * A failed lookup shows an alert with Retry above whatever result was already
+ * on screen; the empty state is suppressed while erroring (#163). Retry sits
+ * outside the `role="alert"` region so its busy-state swaps don't re-announce
+ * the error, and the region is keyed by the failure nonce so a repeated
+ * failure still announces.
  */
 export function TranscriptionDisplay() {
 	const { data: result } = useCurrentTranscription();

--- a/apps/lab/src/app/_hooks/use-transcribe.ts
+++ b/apps/lab/src/app/_hooks/use-transcribe.ts
@@ -5,9 +5,8 @@ import { transcribeWordsAction } from "../_actions/transcribe";
 import { useG2PStore } from "../_store/g2p-store";
 
 /**
- * Thin wrapper over the store's `transcribe`: the orchestration and its
- * staleness token live in the store so every caller (form, example chips,
- * Retry) shares one result and one error, while each keeps its own `isPending`.
+ * Thin wrapper over the store's `transcribe`, which owns the shared result and
+ * error state; each caller keeps its own `isPending`.
  */
 export function useTranscribe() {
 	const [isPending, startTransition] = useTransition();
@@ -24,8 +23,7 @@ export function useTranscribe() {
 	);
 
 	const retry = useCallback(() => {
-		// Retry only ever renders alongside an error, which implies a submitted
-		// text. Logging keeps a broken invariant from becoming a dead button.
+		// `lastText` is always set while an error is showing; log if that breaks.
 		if (lastText) mutate({ text: lastText });
 		else console.error("transcription: retry with no text to replay");
 	}, [lastText, mutate]);

--- a/apps/lab/src/app/_hooks/use-transcribe.ts
+++ b/apps/lab/src/app/_hooks/use-transcribe.ts
@@ -1,90 +1,36 @@
 "use client";
 
-import { useCallback, useRef, useTransition } from "react";
-import type { G2PWord } from "@/lib/g2p/model";
-import { fallbackG2P } from "@/lib/g2p/phoneme-generator";
-import { transformToTranscriptionResult } from "@/lib/g2p-client";
-import { batchLookup, tokenizeText, type WordLookupResult } from "@/lib/phoneme-lookup";
+import { useCallback, useTransition } from "react";
 import { transcribeWordsAction } from "../_actions/transcribe";
 import { useG2PStore } from "../_store/g2p-store";
 
-function lookupResultToG2PWord(result: WordLookupResult): G2PWord {
-	return {
-		word: result.word,
-		variants: result.variants,
-		source: "cmudict",
-	};
-}
-
-let nextRequestId = 0;
-
+/**
+ * Thin wrapper over the store's `transcribe`: the orchestration and its
+ * staleness token live in the store so every caller (form, example chips,
+ * Retry) shares one result and one error, while each keeps its own `isPending`.
+ */
 export function useTranscribe() {
 	const [isPending, startTransition] = useTransition();
-	const resetVariants = useG2PStore((s) => s.resetVariants);
-	const setCurrentResult = useG2PStore((s) => s.setCurrentResult);
-	const latestRequestRef = useRef(0);
+	const transcribe = useG2PStore((s) => s.transcribe);
+	const lastText = useG2PStore((s) => s.lastText);
 
 	const mutate = useCallback(
 		(input: { text: string }) => {
-			const requestId = ++nextRequestId;
-			latestRequestRef.current = requestId;
-
 			startTransition(async () => {
-				try {
-					const tokens = tokenizeText(input.text);
-					if (tokens.length === 0) {
-						setCurrentResult(null);
-						return;
-					}
-
-					const tierResult = await batchLookup(tokens);
-					if (latestRequestRef.current !== requestId) return;
-
-					const serverWordMap = new Map<string, G2PWord>();
-					if (tierResult.missing.length > 0) {
-						const serverWords = await transcribeWordsAction({
-							words: tierResult.missing,
-						});
-						if (latestRequestRef.current !== requestId) return;
-
-						for (const w of serverWords) {
-							serverWordMap.set(w.word, w);
-						}
-					}
-
-					const mergedWords: G2PWord[] = tokens.map((token) => {
-						const normalized = token.toLowerCase().trim();
-
-						const tierWord = tierResult.found.get(normalized);
-						if (tierWord) {
-							return lookupResultToG2PWord(tierWord);
-						}
-
-						const serverWord = serverWordMap.get(normalized);
-						if (serverWord) {
-							return serverWord;
-						}
-
-						return {
-							word: normalized,
-							variants: [fallbackG2P.generatePronunciation(normalized)],
-							source: "fallback" as const,
-						};
-					});
-
-					const transformed = transformToTranscriptionResult({ words: mergedWords }, input.text);
-					setCurrentResult(transformed);
-					resetVariants(transformed.words.length);
-				} catch (error) {
-					if (latestRequestRef.current !== requestId) return;
-					console.error("Transcription failed:", error);
-				}
+				await transcribe(input.text, transcribeWordsAction);
 			});
 		},
-		[setCurrentResult, resetVariants],
+		[transcribe],
 	);
 
-	return { mutate, isPending };
+	const retry = useCallback(() => {
+		// Retry only ever renders alongside an error, which implies a submitted
+		// text. Logging keeps a broken invariant from becoming a dead button.
+		if (lastText) mutate({ text: lastText });
+		else console.error("transcription: retry with no text to replay");
+	}, [lastText, mutate]);
+
+	return { mutate, retry, isPending };
 }
 
 export function useCurrentTranscription() {

--- a/apps/lab/src/app/_store/g2p-store.test.ts
+++ b/apps/lab/src/app/_store/g2p-store.test.ts
@@ -143,6 +143,26 @@ describe("g2p-store — transcribe", () => {
 		expect(state.lookupError).toBeNull();
 	});
 
+	/**
+	 * `mergeWords` reads the server map by normalized token. The real action
+	 * echoes lowercase words, but `transcribeWords` is injectable, so the store
+	 * must not depend on that contract.
+	 */
+	it("merges a server word even when the service echoes its original casing", async () => {
+		const echoingServer: TranscribeWordsFn = async ({ words }) =>
+			words.map((word) => ({
+				word,
+				variants: [[syllable("HH", "AH")]],
+				source: "cmudict" as const,
+			}));
+
+		await useG2PStore.getState().transcribe("Hello", echoingServer, lookupAllMissing);
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult?.words[0]?.source).toBe("cmudict");
+		expect(state.lookupError).toBeNull();
+	});
+
 	it("does nothing for text that tokenizes to nothing", async () => {
 		const server = countingServer();
 		let lookupCalls = 0;
@@ -221,6 +241,17 @@ describe("g2p-store — transcribe", () => {
 		expect(state.lookupError).toBe("unknown");
 		expect(state.isTranscribing).toBe(false);
 		expect(consoleError).toHaveBeenCalled();
+	});
+
+	it("bumps the error nonce on every settled failure so repeats re-announce", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupFails);
+		const first = useG2PStore.getState().lookupErrorNonce;
+
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupFails);
+
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+		expect(useG2PStore.getState().lookupErrorNonce).toBe(first + 1);
 	});
 
 	it("keeps the previous result on screen when a lookup fails", async () => {
@@ -336,6 +367,7 @@ describe("g2p-store — transcribe", () => {
 
 		const state = useG2PStore.getState();
 		expect(state.lookupError).toBeNull();
+		expect(state.lookupErrorNonce).toBe(0);
 		expect(state.lastText).toBeNull();
 		expect(state.currentResult).toBeNull();
 	});

--- a/apps/lab/src/app/_store/g2p-store.test.ts
+++ b/apps/lab/src/app/_store/g2p-store.test.ts
@@ -1,30 +1,84 @@
-import { afterEach, describe, expect, it } from "vitest";
-import type { TranscriptionResult } from "@/lib/types/g2p";
-import { useG2PStore } from "./g2p-store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { G2PSyllable } from "@/lib/g2p/model";
+import type { BatchLookupResult, WordLookupResult } from "@/lib/phoneme-lookup";
+import { type LookupWordsFn, type TranscribeWordsFn, useG2PStore } from "./g2p-store";
 
-const mockResult: TranscriptionResult = {
-	originalText: "hello world",
-	words: [
-		{
-			word: "hello",
-			variants: [],
-			selectedVariantIndex: 0,
-			wordIndex: 0,
-			source: "cmudict",
-		},
-		{
-			word: "world",
-			variants: [],
-			selectedVariantIndex: 0,
-			wordIndex: 1,
-			source: "cmudict",
-		},
-	],
-	timestamp: new Date(),
+function syllable(...cmuTokens: string[]): G2PSyllable {
+	return {
+		phonemes: cmuTokens.map((cmuToken) => ({ cmuToken, phonemeId: null })),
+		stress: "none",
+	};
+}
+
+function foundWord(word: string): WordLookupResult {
+	return {
+		word,
+		cmuVariants: ["HH AH"],
+		variants: [[syllable("HH", "AH")]],
+		source: "tier1",
+	};
+}
+
+/** Every token is a client-tier hit, so the server is never needed. */
+const lookupAllFound: LookupWordsFn = async (words) => ({
+	found: new Map(words.map((word) => [word.toLowerCase(), foundWord(word.toLowerCase())])),
+	missing: [],
+});
+
+/** No token is in the client tiers, so all of them go to the server. */
+const lookupAllMissing: LookupWordsFn = async (words) => ({
+	found: new Map<string, WordLookupResult>(),
+	missing: words,
+});
+
+const lookupFails: LookupWordsFn = async () => {
+	throw new Error("curated-10k chunk failed to load");
 };
+
+/**
+ * A tier hit whose syllable carries no `phonemes` array — the shape
+ * `transformToTranscriptionResult` walks — so the sync merge/transform step
+ * throws on real data rather than on a mocked module.
+ */
+const lookupMalformed: LookupWordsFn = async (words) => ({
+	found: new Map(
+		words.map((word) => [
+			word.toLowerCase(),
+			{
+				...foundWord(word.toLowerCase()),
+				variants: [[{ stress: "none" } as unknown as G2PSyllable]],
+			},
+		]),
+	),
+	missing: [],
+});
+
+/** Records every call so a test can assert the server was (or was not) used. */
+function countingServer(): TranscribeWordsFn & { calls: string[][] } {
+	const calls: string[][] = [];
+	const fn = async ({ words }: { words: string[] }) => {
+		calls.push(words);
+		return words.map((word) => ({
+			word: word.toLowerCase(),
+			variants: [[syllable("W", "ER", "L", "D")]],
+			source: "cmudict" as const,
+		}));
+	};
+	return Object.assign(fn, { calls });
+}
+
+const serverFails: TranscribeWordsFn = async () => {
+	throw new Error("server action unavailable");
+};
+
+/** Puts a real result on screen without reaching for the deleted setters. */
+async function seedResult(text = "hello world"): Promise<void> {
+	await useG2PStore.getState().transcribe(text, countingServer(), lookupAllFound);
+}
 
 afterEach(() => {
 	useG2PStore.getState().clearResult();
+	vi.restoreAllMocks();
 });
 
 describe("g2p-store", () => {
@@ -32,35 +86,257 @@ describe("g2p-store", () => {
 		const state = useG2PStore.getState();
 		expect(state.currentResult).toBeNull();
 		expect(state.selectedVariants).toEqual([]);
+		expect(state.lookupError).toBeNull();
+		expect(state.lastText).toBeNull();
+		expect(state.isTranscribing).toBe(false);
 	});
 
-	it("sets current result", () => {
-		useG2PStore.getState().setCurrentResult(mockResult);
-		expect(useG2PStore.getState().currentResult).toBe(mockResult);
-	});
-
-	it("clears result", () => {
-		useG2PStore.getState().setCurrentResult(mockResult);
+	it("clears result", async () => {
+		await seedResult();
 		useG2PStore.getState().clearResult();
 		expect(useG2PStore.getState().currentResult).toBeNull();
 		expect(useG2PStore.getState().selectedVariants).toEqual([]);
 	});
 
-	it("resets variants for word count", () => {
-		useG2PStore.getState().resetVariants(3);
+	it("sets a specific variant", async () => {
+		await seedResult("one two three");
 		expect(useG2PStore.getState().selectedVariants).toEqual([0, 0, 0]);
-	});
 
-	it("sets a specific variant", () => {
-		useG2PStore.getState().resetVariants(3);
 		useG2PStore.getState().setVariant(1, 2);
 		expect(useG2PStore.getState().selectedVariants).toEqual([0, 2, 0]);
 	});
 
-	it("preserves other variants when setting one", () => {
-		useG2PStore.getState().resetVariants(3);
+	it("preserves other variants when setting one", async () => {
+		await seedResult("one two three");
 		useG2PStore.getState().setVariant(0, 1);
 		useG2PStore.getState().setVariant(2, 3);
 		expect(useG2PStore.getState().selectedVariants).toEqual([1, 0, 3]);
+	});
+});
+
+describe("g2p-store — transcribe", () => {
+	it("transcribes entirely from the client tiers without calling the server", async () => {
+		const server = countingServer();
+		await useG2PStore.getState().transcribe("hello world", server, lookupAllFound);
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult?.words.map((word) => word.word)).toEqual(["hello", "world"]);
+		expect(state.selectedVariants).toEqual([0, 0]);
+		expect(state.lookupError).toBeNull();
+		expect(state.lastText).toBe("hello world");
+		expect(server.calls).toEqual([]);
+	});
+
+	it("sends only the missing words to the server and merges them in", async () => {
+		const server = countingServer();
+		const lookupOneMissing: LookupWordsFn = async (words) => ({
+			found: new Map([["hello", foundWord("hello")]]),
+			missing: words.filter((word) => word !== "hello"),
+		});
+
+		await useG2PStore.getState().transcribe("hello world", server, lookupOneMissing);
+
+		const state = useG2PStore.getState();
+		expect(server.calls).toEqual([["world"]]);
+		expect(state.currentResult?.words[1]).toMatchObject({ word: "world", source: "cmudict" });
+		expect(state.currentResult?.words[0]).toMatchObject({ word: "hello", source: "cmudict" });
+		expect(state.lookupError).toBeNull();
+	});
+
+	it("does nothing for text that tokenizes to nothing", async () => {
+		const server = countingServer();
+		let lookupCalls = 0;
+		const countedLookup: LookupWordsFn = async (words) => {
+			lookupCalls += 1;
+			return lookupAllFound(words);
+		};
+
+		await useG2PStore.getState().transcribe("   ", server, countedLookup);
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult).toBeNull();
+		expect(state.lookupError).toBeNull();
+		expect(state.lastText).toBeNull();
+		expect(lookupCalls).toBe(0);
+		expect(server.calls).toEqual([]);
+	});
+
+	/**
+	 * Input that survives the form's trim gate but tokenizes to nothing must not
+	 * dismiss an error nobody resolved — no lookup was attempted, so the previous
+	 * failure is still true.
+	 */
+	it("keeps an unresolved error when the next input tokenizes to nothing", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		const server = countingServer();
+		await seedResult();
+		await useG2PStore.getState().transcribe("hello", server, lookupFails);
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+
+		await useG2PStore.getState().transcribe("???", server, lookupAllFound);
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult).toBeNull();
+		expect(state.lookupError).toBe("wordlist");
+		expect(server.calls).toEqual([]);
+	});
+
+	it("reports a word list failure when the client lookup throws", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const server = countingServer();
+		await useG2PStore.getState().transcribe("hello", server, lookupFails);
+
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+		expect(consoleError).toHaveBeenCalled();
+		expect(server.calls).toEqual([]);
+	});
+
+	it("reports a service failure when the server action throws", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("xyzzyplugh", serverFails, lookupAllMissing);
+
+		expect(useG2PStore.getState().lookupError).toBe("service");
+		expect(consoleError).toHaveBeenCalled();
+	});
+
+	it("reports an unknown failure when the result cannot be built", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const server = countingServer();
+		await useG2PStore.getState().transcribe("hello", server, lookupMalformed);
+
+		expect(useG2PStore.getState().lookupError).toBe("unknown");
+		expect(consoleError).toHaveBeenCalled();
+		expect(server.calls).toEqual([]);
+	});
+
+	/** The backstop: a server response that is not iterable throws outside every
+	 * inner catch, and must still reach the learner rather than the void. */
+	it("catches a failure no inner handler owns", async () => {
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+		const serverReturnsNothing: TranscribeWordsFn = async () => null as never;
+
+		await useG2PStore.getState().transcribe("xyzzyplugh", serverReturnsNothing, lookupAllMissing);
+
+		const state = useG2PStore.getState();
+		expect(state.lookupError).toBe("unknown");
+		expect(state.isTranscribing).toBe(false);
+		expect(consoleError).toHaveBeenCalled();
+	});
+
+	it("keeps the previous result on screen when a lookup fails", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await seedResult();
+		const firstResult = useG2PStore.getState().currentResult;
+
+		await useG2PStore.getState().transcribe("later text", countingServer(), lookupFails);
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult).toBe(firstResult);
+		expect(state.lookupError).toBe("wordlist");
+	});
+
+	it("clears the error when a retry succeeds", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupFails);
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupAllFound);
+
+		const state = useG2PStore.getState();
+		expect(state.lookupError).toBeNull();
+		expect(state.currentResult?.words.map((word) => word.word)).toEqual(["hello"]);
+	});
+
+	it("keeps the submitted text after a failure, so Retry can replay it", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("hello world", countingServer(), lookupFails);
+
+		expect(useG2PStore.getState().lastText).toBe("hello world");
+	});
+
+	it("drops a stale rejection that lands after a newer transcription succeeded", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		let rejectFirst: (error: Error) => void = () => {};
+		const hangsThenFails: LookupWordsFn = () =>
+			new Promise<BatchLookupResult>((_, reject) => {
+				rejectFirst = reject;
+			});
+
+		const pending = useG2PStore.getState().transcribe("stale", countingServer(), hangsThenFails);
+		await useG2PStore.getState().transcribe("fresh", countingServer(), lookupAllFound);
+
+		rejectFirst(new Error("late chunk failure"));
+		await pending;
+
+		const state = useG2PStore.getState();
+		expect(state.lookupError).toBeNull();
+		expect(state.currentResult?.originalText).toBe("fresh");
+		// The newer call owns the flag; the stale rejection must not re-raise it.
+		expect(state.isTranscribing).toBe(false);
+	});
+
+	it("drops a stale success that lands after a newer transcription succeeded", async () => {
+		let releaseFirst: (result: BatchLookupResult) => void = () => {};
+		const hangsThenResolves: LookupWordsFn = () =>
+			new Promise<BatchLookupResult>((resolve) => {
+				releaseFirst = resolve;
+			});
+
+		const pending = useG2PStore.getState().transcribe("stale", countingServer(), hangsThenResolves);
+		await useG2PStore.getState().transcribe("fresh", countingServer(), lookupAllFound);
+
+		releaseFirst({ found: new Map([["stale", foundWord("stale")]]), missing: [] });
+		await pending;
+
+		const state = useG2PStore.getState();
+		expect(state.currentResult?.originalText).toBe("fresh");
+		expect(state.currentResult?.words.map((word) => word.word)).toEqual(["fresh"]);
+	});
+
+	it("reports that a lookup is in flight until it settles", async () => {
+		let releaseLookup: (result: BatchLookupResult) => void = () => {};
+		const hangs: LookupWordsFn = () =>
+			new Promise<BatchLookupResult>((resolve) => {
+				releaseLookup = resolve;
+			});
+
+		const pending = useG2PStore.getState().transcribe("hello", countingServer(), hangs);
+		expect(useG2PStore.getState().isTranscribing).toBe(true);
+
+		releaseLookup({ found: new Map([["hello", foundWord("hello")]]), missing: [] });
+		await pending;
+
+		expect(useG2PStore.getState().isTranscribing).toBe(false);
+	});
+
+	it("stops reporting a lookup in flight after a failure", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupFails);
+
+		expect(useG2PStore.getState().isTranscribing).toBe(false);
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+	});
+
+	it("stops reporting a lookup in flight on clearResult", async () => {
+		const hangs: LookupWordsFn = () => new Promise<BatchLookupResult>(() => {});
+
+		void useG2PStore.getState().transcribe("hello", countingServer(), hangs);
+		expect(useG2PStore.getState().isTranscribing).toBe(true);
+
+		useG2PStore.getState().clearResult();
+		expect(useG2PStore.getState().isTranscribing).toBe(false);
+	});
+
+	it("resets the error and replay text on clearResult", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		await useG2PStore.getState().transcribe("hello", countingServer(), lookupFails);
+		expect(useG2PStore.getState().lookupError).toBe("wordlist");
+
+		useG2PStore.getState().clearResult();
+
+		const state = useG2PStore.getState();
+		expect(state.lookupError).toBeNull();
+		expect(state.lastText).toBeNull();
+		expect(state.currentResult).toBeNull();
 	});
 });

--- a/apps/lab/src/app/_store/g2p-store.test.ts
+++ b/apps/lab/src/app/_store/g2p-store.test.ts
@@ -36,9 +36,8 @@ const lookupFails: LookupWordsFn = async () => {
 };
 
 /**
- * A tier hit whose syllable carries no `phonemes` array — the shape
- * `transformToTranscriptionResult` walks — so the sync merge/transform step
- * throws on real data rather than on a mocked module.
+ * A tier hit whose syllable carries no `phonemes` array, so the sync
+ * merge/transform step throws on real data rather than on a mocked module.
  */
 const lookupMalformed: LookupWordsFn = async (words) => ({
 	found: new Map(
@@ -71,7 +70,7 @@ const serverFails: TranscribeWordsFn = async () => {
 	throw new Error("server action unavailable");
 };
 
-/** Puts a real result on screen without reaching for the deleted setters. */
+/** Seeds a real result through a successful `transcribe`. */
 async function seedResult(text = "hello world"): Promise<void> {
 	await useG2PStore.getState().transcribe(text, countingServer(), lookupAllFound);
 }
@@ -143,11 +142,6 @@ describe("g2p-store — transcribe", () => {
 		expect(state.lookupError).toBeNull();
 	});
 
-	/**
-	 * `mergeWords` reads the server map by normalized token. The real action
-	 * echoes lowercase words, but `transcribeWords` is injectable, so the store
-	 * must not depend on that contract.
-	 */
 	it("merges a server word even when the service echoes its original casing", async () => {
 		const echoingServer: TranscribeWordsFn = async ({ words }) =>
 			words.map((word) => ({
@@ -181,11 +175,7 @@ describe("g2p-store — transcribe", () => {
 		expect(server.calls).toEqual([]);
 	});
 
-	/**
-	 * Input that survives the form's trim gate but tokenizes to nothing must not
-	 * dismiss an error nobody resolved — no lookup was attempted, so the previous
-	 * failure is still true.
-	 */
+	// "???" survives the form's trim gate but tokenizes to nothing.
 	it("keeps an unresolved error when the next input tokenizes to nothing", async () => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 		const server = countingServer();
@@ -229,8 +219,7 @@ describe("g2p-store — transcribe", () => {
 		expect(server.calls).toEqual([]);
 	});
 
-	/** The backstop: a server response that is not iterable throws outside every
-	 * inner catch, and must still reach the learner rather than the void. */
+	// A non-iterable server response throws outside every inner catch.
 	it("catches a failure no inner handler owns", async () => {
 		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 		const serverReturnsNothing: TranscribeWordsFn = async () => null as never;

--- a/apps/lab/src/app/_store/g2p-store.ts
+++ b/apps/lab/src/app/_store/g2p-store.ts
@@ -31,6 +31,11 @@ interface G2PStore {
 	selectedVariants: number[];
 	/** Set when a lookup failed; cleared when one settles successfully. */
 	lookupError: LookupErrorKind | null;
+	/**
+	 * Bumped on every settled failure. The alert keys on it so a retry that
+	 * fails with the same kind still re-mounts — and re-announces — the alert.
+	 */
+	lookupErrorNonce: number;
 	/** The text Retry replays. Never set for input that tokenized to nothing. */
 	lastText: string | null;
 	/**
@@ -84,6 +89,15 @@ function mergeWords(
 	});
 }
 
+/** The terminal write shared by every failure path. */
+function failed(kind: LookupErrorKind) {
+	return (state: { lookupErrorNonce: number }) => ({
+		lookupError: kind,
+		lookupErrorNonce: state.lookupErrorNonce + 1,
+		isTranscribing: false,
+	});
+}
+
 /**
  * Monotonic id for the in-flight transcription. It is module-level, not
  * per-hook: the form, the example chips and Retry each instantiate their own
@@ -96,6 +110,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 	currentResult: null,
 	selectedVariants: [],
 	lookupError: null,
+	lookupErrorNonce: 0,
 	lastText: null,
 	isTranscribing: false,
 
@@ -106,6 +121,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 			currentResult: null,
 			selectedVariants: [],
 			lookupError: null,
+			lookupErrorNonce: 0,
 			lastText: null,
 			isTranscribing: false,
 		});
@@ -142,7 +158,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 			} catch (error) {
 				if (activeLookup !== token) return;
 				console.error("transcription: word list lookup failed", error);
-				set({ lookupError: "wordlist", isTranscribing: false });
+				set(failed("wordlist"));
 				return;
 			}
 			// A newer transcription took over mid-flight — drop this one. It owns
@@ -157,13 +173,16 @@ export const useG2PStore = create<G2PStore>((set) => ({
 				} catch (error) {
 					if (activeLookup !== token) return;
 					console.error("transcription: lookup service failed", error);
-					set({ lookupError: "service", isTranscribing: false });
+					set(failed("service"));
 					return;
 				}
 				if (activeLookup !== token) return;
 
 				for (const word of serverWords) {
-					serverWordMap.set(word.word, word);
+					// `mergeWords` looks the map up by normalized token. The real action
+					// echoes lowercase words, but `transcribeWords` is injectable, so the
+					// key is normalized here rather than trusting that contract.
+					serverWordMap.set(word.word.toLowerCase().trim(), word);
 				}
 			}
 
@@ -176,7 +195,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 			} catch (error) {
 				// Nothing is awaited since the last guard, so this lookup is still live.
 				console.error("transcription: building the result failed", error);
-				set({ lookupError: "unknown", isTranscribing: false });
+				set(failed("unknown"));
 				return;
 			}
 
@@ -191,7 +210,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 		} catch (error) {
 			if (activeLookup !== token) return;
 			console.error("transcription: unexpected failure", error);
-			set({ lookupError: "unknown", isTranscribing: false });
+			set(failed("unknown"));
 		}
 	},
 }));

--- a/apps/lab/src/app/_store/g2p-store.ts
+++ b/apps/lab/src/app/_store/g2p-store.ts
@@ -1,32 +1,113 @@
 import { create } from "zustand";
+import type { G2PWord } from "@/lib/g2p/model";
+import { fallbackG2P } from "@/lib/g2p/phoneme-generator";
+import { transformToTranscriptionResult } from "@/lib/g2p-client";
+import {
+	type BatchLookupResult,
+	batchLookup,
+	tokenizeText,
+	type WordLookupResult,
+} from "@/lib/phoneme-lookup";
 import type { TranscriptionResult } from "@/lib/types/g2p";
+
+/**
+ * Which stage of the lookup failed. Server-action errors are digest-opaque in
+ * production, so the kind comes from the catch scope, never from the message.
+ * The learner-facing copy lives with the component that renders it.
+ */
+export type LookupErrorKind = "wordlist" | "service" | "unknown";
+
+/**
+ * The server action is injected instead of imported: `../_actions/transcribe`
+ * pulls in `@/db/drizzle`, which throws at import time when `TURSO_DATABASE_URL`
+ * is unset — importing it here would break this store's test at module load.
+ * The client-side lookup has no such problem, so it defaults to `batchLookup`.
+ */
+export type TranscribeWordsFn = (input: { words: string[] }) => Promise<G2PWord[]>;
+export type LookupWordsFn = (words: string[]) => Promise<BatchLookupResult>;
 
 interface G2PStore {
 	currentResult: TranscriptionResult | null;
 	selectedVariants: number[];
+	/** Set when a lookup failed; cleared when one settles successfully. */
+	lookupError: LookupErrorKind | null;
+	/** The text Retry replays. Never set for input that tokenized to nothing. */
+	lastText: string | null;
+	/**
+	 * True while a lookup is in flight. `useTransition`'s `isPending` is
+	 * per-hook-instance, so a lookup fired from the form would otherwise leave
+	 * Retry (a different instance) looking idle.
+	 */
+	isTranscribing: boolean;
 
-	setCurrentResult: (result: TranscriptionResult | null) => void;
-	resetVariants: (wordCount: number) => void;
 	clearResult: () => void;
 	setVariant: (wordIndex: number, variantIndex: number) => void;
+	transcribe: (
+		text: string,
+		transcribeWords: TranscribeWordsFn,
+		lookupWords?: LookupWordsFn,
+	) => Promise<void>;
 }
+
+function lookupResultToG2PWord(result: WordLookupResult): G2PWord {
+	return {
+		word: result.word,
+		variants: result.variants,
+		source: "cmudict",
+	};
+}
+
+/** Precedence per token: client tier hit → server word → client fallback. */
+function mergeWords(
+	tokens: string[],
+	tierResult: BatchLookupResult,
+	serverWords: Map<string, G2PWord>,
+): G2PWord[] {
+	return tokens.map((token) => {
+		const normalized = token.toLowerCase().trim();
+
+		const tierWord = tierResult.found.get(normalized);
+		if (tierWord) {
+			return lookupResultToG2PWord(tierWord);
+		}
+
+		const serverWord = serverWords.get(normalized);
+		if (serverWord) {
+			return serverWord;
+		}
+
+		return {
+			word: normalized,
+			variants: [fallbackG2P.generatePronunciation(normalized)],
+			source: "fallback" as const,
+		};
+	});
+}
+
+/**
+ * Monotonic id for the in-flight transcription. It is module-level, not
+ * per-hook: the form, the example chips and Retry each instantiate their own
+ * `useTranscribe`, so a per-instance ref could not tell one instance's stale
+ * result from another instance's live one.
+ */
+let activeLookup = 0;
 
 export const useG2PStore = create<G2PStore>((set) => ({
 	currentResult: null,
 	selectedVariants: [],
-
-	setCurrentResult: (result: TranscriptionResult | null) => {
-		set({ currentResult: result });
-	},
-
-	resetVariants: (wordCount: number) => {
-		set({ selectedVariants: Array(wordCount).fill(0) });
-	},
+	lookupError: null,
+	lastText: null,
+	isTranscribing: false,
 
 	clearResult: () => {
+		// Any in-flight lookup belongs to the result being cleared.
+		activeLookup += 1;
 		set({
 			currentResult: null,
 			selectedVariants: [],
+			lookupError: null,
+			lastText: null,
+			isTranscribing: false,
 		});
 	},
 
@@ -36,5 +117,81 @@ export const useG2PStore = create<G2PStore>((set) => ({
 			next[wordIndex] = variantIndex;
 			return { selectedVariants: next };
 		});
+	},
+
+	transcribe: async (text, transcribeWords, lookupWords = batchLookup) => {
+		const token = ++activeLookup;
+
+		// Outer backstop: `transcribe` runs inside `startTransition`, where a throw
+		// would be an unhandled rejection and the learner would see nothing. Total
+		// by construction rather than by audit — the inner catches still classify.
+		try {
+			const tokens = tokenizeText(text);
+			if (tokens.length === 0) {
+				// Nothing was looked up, so an unresolved `lookupError` is still true
+				// and stays on screen; `lastText` stays put so Retry never replays "".
+				set({ currentResult: null, selectedVariants: [], isTranscribing: false });
+				return;
+			}
+
+			set({ lastText: text, isTranscribing: true });
+
+			let tierResult: BatchLookupResult;
+			try {
+				tierResult = await lookupWords(tokens);
+			} catch (error) {
+				if (activeLookup !== token) return;
+				console.error("transcription: word list lookup failed", error);
+				set({ lookupError: "wordlist", isTranscribing: false });
+				return;
+			}
+			// A newer transcription took over mid-flight — drop this one. It owns
+			// `isTranscribing` now, so a stale return never touches the flag.
+			if (activeLookup !== token) return;
+
+			const serverWordMap = new Map<string, G2PWord>();
+			if (tierResult.missing.length > 0) {
+				let serverWords: G2PWord[];
+				try {
+					serverWords = await transcribeWords({ words: tierResult.missing });
+				} catch (error) {
+					if (activeLookup !== token) return;
+					console.error("transcription: lookup service failed", error);
+					set({ lookupError: "service", isTranscribing: false });
+					return;
+				}
+				if (activeLookup !== token) return;
+
+				for (const word of serverWords) {
+					serverWordMap.set(word.word, word);
+				}
+			}
+
+			let transformed: TranscriptionResult;
+			try {
+				transformed = transformToTranscriptionResult(
+					{ words: mergeWords(tokens, tierResult, serverWordMap) },
+					text,
+				);
+			} catch (error) {
+				// Nothing is awaited since the last guard, so this lookup is still live.
+				console.error("transcription: building the result failed", error);
+				set({ lookupError: "unknown", isTranscribing: false });
+				return;
+			}
+
+			// The error clears on settle, not on start, so the alert — and its Retry
+			// button — stays mounted while the retry is in flight.
+			set({
+				currentResult: transformed,
+				selectedVariants: Array(transformed.words.length).fill(0),
+				lookupError: null,
+				isTranscribing: false,
+			});
+		} catch (error) {
+			if (activeLookup !== token) return;
+			console.error("transcription: unexpected failure", error);
+			set({ lookupError: "unknown", isTranscribing: false });
+		}
 	},
 }));

--- a/apps/lab/src/app/_store/g2p-store.ts
+++ b/apps/lab/src/app/_store/g2p-store.ts
@@ -13,7 +13,6 @@ import type { TranscriptionResult } from "@/lib/types/g2p";
 /**
  * Which stage of the lookup failed. Server-action errors are digest-opaque in
  * production, so the kind comes from the catch scope, never from the message.
- * The learner-facing copy lives with the component that renders it.
  */
 export type LookupErrorKind = "wordlist" | "service" | "unknown";
 
@@ -21,7 +20,6 @@ export type LookupErrorKind = "wordlist" | "service" | "unknown";
  * The server action is injected instead of imported: `../_actions/transcribe`
  * pulls in `@/db/drizzle`, which throws at import time when `TURSO_DATABASE_URL`
  * is unset — importing it here would break this store's test at module load.
- * The client-side lookup has no such problem, so it defaults to `batchLookup`.
  */
 export type TranscribeWordsFn = (input: { words: string[] }) => Promise<G2PWord[]>;
 export type LookupWordsFn = (words: string[]) => Promise<BatchLookupResult>;
@@ -31,17 +29,13 @@ interface G2PStore {
 	selectedVariants: number[];
 	/** Set when a lookup failed; cleared when one settles successfully. */
 	lookupError: LookupErrorKind | null;
-	/**
-	 * Bumped on every settled failure. The alert keys on it so a retry that
-	 * fails with the same kind still re-mounts — and re-announces — the alert.
-	 */
+	/** Bumped on each settled failure so the alert re-mounts and re-announces. */
 	lookupErrorNonce: number;
 	/** The text Retry replays. Never set for input that tokenized to nothing. */
 	lastText: string | null;
 	/**
-	 * True while a lookup is in flight. `useTransition`'s `isPending` is
-	 * per-hook-instance, so a lookup fired from the form would otherwise leave
-	 * Retry (a different instance) looking idle.
+	 * True while a lookup is in flight. Shared here because `isPending` is
+	 * per-hook-instance and Retry lives in a different instance than the form.
 	 */
 	isTranscribing: boolean;
 
@@ -99,10 +93,8 @@ function failed(kind: LookupErrorKind) {
 }
 
 /**
- * Monotonic id for the in-flight transcription. It is module-level, not
- * per-hook: the form, the example chips and Retry each instantiate their own
- * `useTranscribe`, so a per-instance ref could not tell one instance's stale
- * result from another instance's live one.
+ * Monotonic id for the in-flight transcription. Module-level, not per-hook:
+ * the form, the example chips and Retry each own a `useTranscribe` instance.
  */
 let activeLookup = 0;
 
@@ -138,9 +130,8 @@ export const useG2PStore = create<G2PStore>((set) => ({
 	transcribe: async (text, transcribeWords, lookupWords = batchLookup) => {
 		const token = ++activeLookup;
 
-		// Outer backstop: `transcribe` runs inside `startTransition`, where a throw
-		// would be an unhandled rejection and the learner would see nothing. Total
-		// by construction rather than by audit — the inner catches still classify.
+		// Backstop: a throw escaping here becomes an unhandled rejection inside
+		// `startTransition`, which the learner never sees.
 		try {
 			const tokens = tokenizeText(text);
 			if (tokens.length === 0) {
@@ -161,8 +152,7 @@ export const useG2PStore = create<G2PStore>((set) => ({
 				set(failed("wordlist"));
 				return;
 			}
-			// A newer transcription took over mid-flight — drop this one. It owns
-			// `isTranscribing` now, so a stale return never touches the flag.
+			// A newer transcription owns the state now — return without touching it.
 			if (activeLookup !== token) return;
 
 			const serverWordMap = new Map<string, G2PWord>();
@@ -179,9 +169,8 @@ export const useG2PStore = create<G2PStore>((set) => ({
 				if (activeLookup !== token) return;
 
 				for (const word of serverWords) {
-					// `mergeWords` looks the map up by normalized token. The real action
-					// echoes lowercase words, but `transcribeWords` is injectable, so the
-					// key is normalized here rather than trusting that contract.
+					// Key by normalized token (what `mergeWords` reads) — `transcribeWords`
+					// is injectable, so don't rely on the server echoing lowercase.
 					serverWordMap.set(word.word.toLowerCase().trim(), word);
 				}
 			}
@@ -199,8 +188,8 @@ export const useG2PStore = create<G2PStore>((set) => ({
 				return;
 			}
 
-			// The error clears on settle, not on start, so the alert — and its Retry
-			// button — stays mounted while the retry is in flight.
+			// Errors clear on settle, not on start, so the alert stays mounted
+			// while a retry is in flight.
 			set({
 				currentResult: transformed,
 				selectedVariants: Array(transformed.words.length).fill(0),


### PR DESCRIPTION
## Summary

Transcription lookups previously swallowed every error — the single catch in `use-transcribe` only logged to the console, so a failed lookup was indistinguishable from the app ignoring the learner. This includes the ~330 KB tier-2 curated-10k dynamic import (awaited before tier-1 is even consulted, so a chunk failure blocked *every* transcription) and the tier-3 server action → Turso path.

Any lookup failure now produces a visible, plain-language error with a Retry button, distinguishing "couldn't load the word list" from "couldn't reach the lookup service", following the practice module's failure patterns (#140/#147/#156).

Closes #163

## Design

- **Orchestration moved into `g2p-store`** as `transcribe(text, transcribeWords, lookupWords = batchLookup)`, mirroring the practice store's `prefetchPool`. Error state must be shared: `useTranscribe()` is instantiated by the form, the example chips, and now the Retry button.
- **Failure kind comes from the catch scope, never the message** — server-action errors are digest-opaque in production. `"wordlist"` = tier-2 chunk import, `"service"` = server action, `"unknown"` = transform failures plus an outer backstop that makes `transcribe` total by construction.
- **Shared monotonic staleness token** (`activeLookup`, the practice store's `activeLoad` idiom) replaces the per-hook-instance ref — fixing a pre-existing race where the form and the example chips could clobber each other's results.
- **Server action is injected, not imported, by the store**: `../_actions/transcribe` pulls `@/db/drizzle`, which throws at import when `TURSO_DATABASE_URL` is unset — a static import would break the store's test at module load.
- **Retry replays the last submitted text.** The already-present `retryable-loader` clears its rejected memo, so a retry genuinely re-fetches the failed chunk; the server path has no negative caching on failure.
- **Error clears on settle, not on start**, so the alert (and its Retry button) stays mounted while a retry is in flight. Submitting input that tokenizes to nothing does *not* dismiss an unresolved error.
- **UI**: inline `role="alert"` box + outline Retry in the results area, styled identically to the practice start screen (chosen over a toast per the repo's own decision rule from #140). The Retry button sits *outside* the alert live region so screen readers don't re-announce the error on click, and shows busy while a lookup from any trigger is in flight (store-level `isTranscribing`). A previous successful result stays on screen beneath the alert, captioned "Showing your last transcription for …". Example chips are suppressed while erroring.
- The server-side fallback G2P path (`processWords` → `fallbackG2P`) is untouched.

## Testing

- 21 tests in `g2p-store.test.ts` (repo-idiomatic: dependency injection, `getState()`, manually-released promises — no jsdom/RTL): all three error kinds, retry recovery, stale success/failure suppression, previous-result preservation, `isTranscribing` lifecycle, the outer backstop, error-not-dismissable-by-punctuation-input, `clearResult` reset.
- `bun --filter @phonaria/lab test`: 266/266 · `bun lint`: clean · `bun --filter @phonaria/lab check-types`: clean.
- Reviewed by two adversarial passes (general + silent-failure hunt); all medium findings fixed in-branch.

## Out of scope (tracked / noted)

- Same bug in `apps/web` (whose tier-2 loader isn't retryable at all): #172.
- No telemetry when the word-list chunk fails for a client; pre-existing silent failures in `cmudict.ts` `mapVariants` (corrupt row degrades to "Not found") and the copy button's clipboard catch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback transcription when word-list lookup is unavailable.
  * Added retry support for failed transcriptions, including loading feedback.
  * Preserved previous results and clearly marked them as outdated during errors.
  * Added clearer error messages for lookup and service failures.

* **Bug Fixes**
  * Prevented outdated requests from overwriting newer transcription results.
  * Improved handling of empty input and malformed responses.
  * Automatically initialized transcription results and variant selections after successful requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->